### PR TITLE
add yaw-pitch-roll angles

### DIFF
--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -737,16 +737,18 @@ class Quaternion:
             yaw:    rotation angle around the z-axis in radians, in the range `[-pi, pi]`
             pitch:  rotation angle around the y'-axis in radians, in the range `[-pi/2, -pi/2]`
             roll:   rotation angle around the x''-axis in radians, in the range `[-pi, pi]` 
+        
+        The resulting rotation_matrix would be R = R_x(roll) R_y(pitch) R_z(yaw)
             
         Note: 
             This feature only makes sense when referring to a unit quaternion. Calling this method will implicitly normalise the Quaternion object to a unit quaternion if it is not already one.
         """
         
         self._normalise()
-        yaw = np.arctan2(2*(self.q[0]*self.q[3] + self.q[1]*self.q[2]), 
+        yaw = np.arctan2(2*(self.q[0]*self.q[3] - self.q[1]*self.q[2]), 
             1 - 2*(self.q[2]**2 + self.q[3]**2))
-        pitch = np.arcsin(2*(self.q[0]*self.q[2] - self.q[3]*self.q[1]))
-        roll = np.arctan2(2*(self.q[0]*self.q[1] + self.q[2]*self.q[3]), 
+        pitch = np.arcsin(2*(self.q[0]*self.q[2] + self.q[3]*self.q[1]))
+        roll = np.arctan2(2*(self.q[0]*self.q[1] - self.q[2]*self.q[3]), 
             1 - 2*(self.q[1]**2 + self.q[2]**2))
 
         return yaw, pitch, roll         

--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -729,6 +729,28 @@ class Quaternion:
         Rt = np.hstack([self.rotation_matrix, t])
         return np.vstack([Rt, np.array([0.0, 0.0, 0.0, 1.0])])
 
+    @property
+    def yaw_pitch_roll(self):
+        """Get the equivalent yaw-pitch-roll angles aka. intrinsic Tait-Bryan angles following the z-y'-x'' convention
+        
+        Returns:
+            yaw:    rotation angle around the z-axis in radians, in the range `[-pi, pi]`
+            pitch:  rotation angle around the y'-axis in radians, in the range `[-pi/2, -pi/2]`
+            roll:   rotation angle around the x''-axis in radians, in the range `[-pi, pi]` 
+            
+        Note: 
+            This feature only makes sense when referring to a unit quaternion. Calling this method will implicitly normalise the Quaternion object to a unit quaternion if it is not already one.
+        """
+        
+        self._normalise()
+        yaw = np.arctan2(2*(self.q[0]*self.q[3] + self.q[1]*self.q[2]), 
+            1 - 2*(self.q[2]**2 + self.q[3]**2))
+        pitch = np.arcsin(2*(self.q[0]*self.q[2] - self.q[3]*self.q[1]))
+        roll = np.arctan2(2*(self.q[0]*self.q[1] + self.q[2]*self.q[3]), 
+            1 - 2*(self.q[1]**2 + self.q[2]**2))
+
+        return yaw, pitch, roll         
+
     def _wrap_angle(self, theta):
         """Helper method: Wrap any angle to lie between -pi and pi 
 

--- a/pyquaternion/test/test_quaternion.py
+++ b/pyquaternion/test/test_quaternion.py
@@ -821,13 +821,19 @@ class TestQuaternionFeatures(unittest.TestCase):
                 [ s, c, 0],
                 [ 0, 0, 1]])
 
+        p = np.random.randn(3)
         q = Quaternion.random()
         yaw, pitch, roll = q.yaw_pitch_roll
 
+        p_q = q.rotate(p)
+        R_q = q.rotation_matrix
+
         # build rotation matrix, R = R_z(yaw)*R_y(pitch)*R_x(roll)
-        R = np.dot(np.dot(R_z(yaw), R_y(pitch)), R_x(roll))
+        R_ypr = np.dot(R_x(roll), np.dot(R_y(pitch), R_z(yaw)))
+        p_ypr = np.dot(R_ypr, p)
         
-        np.testing.assert_almost_equal(R, q.rotation_matrix, decimal=ALMOST_EQUAL_TOLERANCE)
+        np.testing.assert_almost_equal(p_q , p_ypr, decimal=ALMOST_EQUAL_TOLERANCE)
+        np.testing.assert_almost_equal(R_q , R_ypr, decimal=ALMOST_EQUAL_TOLERANCE)
 
     def test_matrix_io(self):
         v = np.random.uniform(-100, 100, 3)

--- a/pyquaternion/test/test_quaternion.py
+++ b/pyquaternion/test/test_quaternion.py
@@ -795,6 +795,40 @@ class TestQuaternionFeatures(unittest.TestCase):
         np.testing.assert_almost_equal(v1_, q.rotate(v1), decimal=ALMOST_EQUAL_TOLERANCE)
         np.testing.assert_almost_equal(v2_[0:3], q.rotate(v2[0:3]), decimal=ALMOST_EQUAL_TOLERANCE)
 
+    def test_conversion_to_ypr(self):
+    
+        def R_x(theta):
+            c = cos(theta)
+            s = sin(theta)
+            return np.array([
+                [1, 0, 0],
+                [0, c,-s],
+                [0, s, c]])
+    
+        def R_y(theta):
+            c = cos(theta)
+            s = sin(theta)
+            return np.array([
+                [ c, 0, s],
+                [ 0, 1, 0],
+                [-s, 0, c]])
+    
+        def R_z(theta):
+            c = cos(theta)
+            s = sin(theta)
+            return np.array([
+                [ c,-s, 0],
+                [ s, c, 0],
+                [ 0, 0, 1]])
+
+        q = Quaternion.random()
+        yaw, pitch, roll = q.yaw_pitch_roll
+
+        # build rotation matrix, R = R_z(yaw)*R_y(pitch)*R_x(roll)
+        R = np.dot(np.dot(R_z(yaw), R_y(pitch)), R_x(roll))
+        
+        np.testing.assert_almost_equal(R, q.rotation_matrix, decimal=ALMOST_EQUAL_TOLERANCE)
+
     def test_matrix_io(self):
         v = np.random.uniform(-100, 100, 3)
 


### PR DESCRIPTION
Convert quaternion into the equivalent yaw-pitch-roll angles aka. intrinsic Tait-Bryan angles following the z-y'-x'' convention.