### PR TITLE
Instance properties (w, x, y, z) for quaternion components

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -726,6 +726,27 @@ This property returns **v**
 	v = my_quaternion.imaginary
 
 ## Accessing individual elements
+> **`w`**
+
+> **`x`**
+
+> **`y`**
+
+> **`z`**
+
+Get the element of the quaternion object corresponding to the attribute. The quaternion object's elements are represented as `(w, x, y, z)`. Result is not guaranteed to be normalized such that each element comes from a unit 4-vector.
+
+**Returns:** a scalar, real valued element corresponding to the accessed attribute.
+
+	>>> print(my_quaternion.w)
+        -0.6753741977725701
+    >>> print(my_quaternion.x)
+        0.4624451782281068
+    >>> print(my_quaternion.y)
+        -0.059197245808339134
+    >>> print(my_quaternion.z)
+        0.5714103921047806
+	
 > **`elements`**
 
 Return all four elements of the quaternion object. Result is not guaranteed to be a unit 4-vector.

--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -1085,6 +1085,22 @@ class Quaternion:
         return self.vector
 
     @property
+    def w(self):
+        return self.q[0]
+
+    @property
+    def x(self):
+        return self.q[1]
+
+    @property
+    def y(self):
+        return self.q[2]
+
+    @property
+    def z(self):
+        return self.q[3]
+
+    @property
     def elements(self):
         """ Return all the elements of the quaternion object.
 

--- a/pyquaternion/test/test_quaternion.py
+++ b/pyquaternion/test/test_quaternion.py
@@ -726,6 +726,10 @@ class TestQuaternionFeatures(unittest.TestCase):
         self.assertTrue(np.array_equal(q.imaginary, [b, c, d]))
         self.assertEqual(tuple(q.vector), (b, c, d))
         self.assertEqual(list(q.imaginary), [b, c, d])
+        self.assertEqual(q.w, a)
+        self.assertEqual(q.x, b)
+        self.assertEqual(q.y, c)
+        self.assertEqual(q.z, d)
 
     def test_output_of_elements(self):
         r = randomElements()


### PR DESCRIPTION
Added `properties` to the Quaternion class to allow access to individual quaternion components in a clean, notational manner.