### PR TITLE
Fixed 3D projection error.

### DIFF
--- a/demo/demo2.py
+++ b/demo/demo2.py
@@ -41,6 +41,7 @@ from pyquaternion import Quaternion
 
 from matplotlib import pyplot as plt
 from matplotlib import animation
+from mpl_toolkits.mplot3d import Axes3D
 
 def generate_quaternion():
 	q1 = Quaternion.random()


### PR DESCRIPTION
With the current demo, if you try to run the code you will get an error: ValueError: Unknown projection 3d. The solution is tested and works for both Python 2 and Python 3 on Ubuntu with matplotlib==2.2.3.