### PR TITLE
Allow imperfect rotation matrices to be used

### DIFF
--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -97,7 +97,7 @@ class Quaternion:
                 elif "array" in kwargs:
                     self.q = self._validate_number_sequence(kwargs["array"], 4)
                 elif "matrix" in kwargs:
-                    self.q = Quaternion._from_matrix(kwargs["matrix"]).q
+                    self.q = Quaternion._from_matrix(kwargs["matrix"], force_imperfect=kwargs.get("force_imperfect", False)).q
                 else:
                     keys = sorted(kwargs.keys())
                     elements = [kwargs[kw] for kw in keys]
@@ -156,7 +156,7 @@ class Quaternion:
 
     # Initialise from matrix
     @classmethod
-    def _from_matrix(cls, matrix):
+    def _from_matrix(cls, matrix, force_imperfect=False):
         """Initialise from matrix representation
 
         Create a Quaternion by specifying the 3x3 rotation or 4x4 transformation matrix
@@ -175,11 +175,12 @@ class Quaternion:
         else:
             raise ValueError("Invalid matrix shape: Input must be a 3x3 or 4x4 numpy array or matrix")
 
-        # Check matrix properties
-        if not np.allclose(np.dot(R, R.conj().transpose()), np.eye(3)):
-            raise ValueError("Matrix must be orthogonal, i.e. its transpose should be its inverse")
-        if not np.isclose(np.linalg.det(R), 1.0):
-            raise ValueError("Matrix must be special orthogonal i.e. its determinant must be +1.0")
+        if not force_imperfect:
+            # Check matrix properties
+            if not np.allclose(np.dot(R, R.conj().transpose()), np.eye(3)):
+                raise ValueError("Matrix must be orthogonal, i.e. its transpose should be its inverse")
+            if not np.isclose(np.linalg.det(R), 1.0):
+                raise ValueError("Matrix must be special orthogonal i.e. its determinant must be +1.0")
 
         def decomposition_method(matrix):
             """ Method supposedly able to deal with non-orthogonal matrices - NON-FUNCTIONAL!


### PR DESCRIPTION
Hi! Thanks for that nice lib! 
I used it in a project where I had to convert rotation matrices output by ARtoolkit into quaternions. My problem is that their matrices are not perfectly clean and have some errors that will for instance turn unit vectors in the correct direction but maybe with a length of 1.000001. 

I needed a way to bypass the tests that check if the matrix provided is really orthogonal. 

I am not sure if you will want to include that workaround in your code as this is pretty niche use, but here it is in case you want it.