### PR TITLE
resolve float method

### DIFF
--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -318,7 +318,7 @@ class Quaternion:
         Truncates the Quaternion object by only considering the real
         component.
         """
-        return self.q[0]
+        return float(self.q[0])
 
     def __complex__(self):
         """Implements type conversion to complex.


### PR DESCRIPTION
in the python version 3.7 I have an error with float method that says it does not return a float number (numpy.float64)