### PR TITLE
Quaternion from Matrix Optional Args

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,7 @@ A Quaternion object can be created in the following ways:
 ## Default
 > **`Quaternion()`**
 
-Creates a unit quaternion `1 + 0i + 0j + 0k`: the quaternion representation of the real number 1.0, 
+Creates a unit quaternion `1 + 0i + 0j + 0k`: the quaternion representation of the real number 1.0,
 and the representation of a null rotation.
 
     q1 = Quaternion()
@@ -279,7 +279,18 @@ Specify the 3x3 rotation matrix (`R`) or 4x4 transformation matrix (`T`) from wh
 **Params:**
 
 * `matrix=R` can be a 3x3 numpy array or matrix
-* `matrix=T` can be a 4x4 numpy array or matrix. In this case, the translation part will be ignored, and only the rotational component of the matrix will be encoded within the quaternion.
+* `matrix=T` can be a 4x4 numpy array or matrix. In this case, the translation part will be ignored, and only the rotational
+
+
+**Optional Params:**
+
+When initializing a Quaternion explicitly from a matrix, an assertion is raised if it is not special orthogoal. Numpy's [allclose](https://docs.scipy.org/doc/numpy/reference/generated/numpy.allclose.html) function is used as part of this operation. The default relative and absolute tolerance values used are 1.e-5 and 1.e-8 respectively. These can be optionally overwritten when initializing a Quaternion as follows:
+
+> **`Quaternion(matrix=R, atol=atol, rtol=rtol)`**
+> e.g. **`Quaternion(matrix=R, atol=1e-07, rtol=1e-07)`**
+
+* `rtol=rtol` The relative tolerance parameter. [See Notes](https://docs.scipy.org/doc/numpy/reference/generated/numpy.allclose.html)
+* `atol=atol` The absolute tolerance parameter.[See Notes](https://docs.scipy.org/doc/numpy/reference/generated/numpy.allclose.html)
 
 **Important:** The rotation component of the provided matrix must be a pure rotation i.e. [special orthogonal](http://mathworld.wolfram.com/SpecialOrthogonalMatrix.html).
 
@@ -412,7 +423,7 @@ Quaternion Exponential.
 * `q` - the input quaternion/argument as a Quaternion object.
 
 **Returns:** A quaternion amount representing the exp(q). See [Source](https://math.stackexchange.com/questions/1030737/exponential-function-of-quaternion-derivation for more information and mathematical background).
-           
+
 **Note:** The method can compute the exponential of any quaternion.
 
 > **`Quaternion.log(q)`** - *class method*
@@ -426,7 +437,7 @@ Quaternion Logarithm.
 **Returns:** A quaternion amount representing `log(q) := (log(|q|), v/|v|acos(w/|q|))`.
 
 **Note:** The method computes the logarithm of general quaternions. See [Source](https://math.stackexchange.com/questions/2552/the-logarithm-of-quaternion/2554#2554) for more details.
-        
+
 > **`Quaternion.exp_map(q, eta)`** - *class method*
 
 Quaternion exponential map.
@@ -449,7 +460,7 @@ Quaternion symmetrized exponential map.
 Find the symmetrized exponential map on the quaternion Riemannian manifold.
 
 **Params:**
-             
+
 * `q` - the base point as a Quaternion object
 * `eta` - the tangent vector argument of the exponential map as a Quaternion object
 
@@ -478,14 +489,14 @@ Quaternion symmetrized logarithm map.
 Find the symmetrized logarithm map on the quaternion Riemannian manifold.
 
 **Params:**
-             
+
 * `q` - the base point at which the logarithm is computed, i.e. a Quaternion object
 * `p` - the argument of the quaternion map, a Quaternion object
 
 **Returns:** A tangent vector corresponding to the symmetrized geodesic curve formulation.
 
 **Note:** Information on the symmetrized formulations given in [Source](https://www.researchgate.net/publication/267191489_Riemannian_L_p_Averaging_on_Lie_Group_of_Nonzero_Quaternions).
-        
+
 ## Distance computation
 
 > **`Quaternion.absolute_distance(q0, q1)`** - *class method*
@@ -510,14 +521,14 @@ Quaternion intrinsic distance.
 Find the intrinsic geodesic distance between q0 and q1.
 
 **Params:**
-            
+
 * `q0` - the first quaternion
 * `q1` - the second quaternion
 
 **Returns:** A positive amount corresponding to the length of the geodesic arc connecting q0 to q1.
 
 **Note:** Although `q0^(-1)*q1 != q1^(-1)*q0`, the length of the path joining them is given by the logarithm of those product quaternions, the norm of which is the same.
-       
+
 > **`Quaternion.sym_distance(q0, q1)`** - *class method*
 
 Quaternion symmetrized distance.
@@ -534,7 +545,7 @@ Find the intrinsic symmetrized geodesic distance between q0 and q1.
 **Note:** This formulation is more numerically stable when performing iterative gradient descent on the Riemannian quaternion manifold.
 However, the distance between q and -q is equal to pi, rendering this formulation not useful for measuring rotation similarities when the samples are spread over a "solid" angle of more than pi/2 radians (the spread refers to quaternions as point samples on the unit hypersphere).
 
-    
+
 ## Interpolation
 
 > **`Quaternion.slerp(q0, q1, amount=0.5)`** - *class method*
@@ -660,7 +671,7 @@ alternative `get_axis()` form, specifying the `undefined` keyword to return a ve
 
 **Params:**
 
-* `undefined` - [optional] - specify the axis vector that should define a null rotation. 
+* `undefined` - [optional] - specify the axis vector that should define a null rotation.
 
 **Returns:** a Numpy unit 3-vector describing the Quaternion object's axis of rotation.
 
@@ -668,7 +679,7 @@ alternative `get_axis()` form, specifying the `undefined` keyword to return a ve
 
 **Note 2:** Both matrices and quaternions avoid the singularities and discontinuities involved with rotation in 3 dimensions by adding extra dimensions. This has the effect that different values could represent the same rotation, for example quaternion q and -q represent the same rotation. It is therefore possible that, when converting a rotation sequence to axis/angle representation, the output may jump between different but equivalent forms. This could cause problems where subsequent operations such as differentiation are done on this data. Programmers should be aware of this issue.
 
-	u = my_quaternion.axis # Unit vector about which rotation occurs  #or 
+	u = my_quaternion.axis # Unit vector about which rotation occurs  #or
 	u = my_quaternion.get_axis(undefined=[1, 0, 0]) # Prefers a custom axis vector in the case of undefined result
 
 
@@ -746,7 +757,7 @@ Get the element of the quaternion object corresponding to the attribute. The qua
         -0.059197245808339134
     >>> print(my_quaternion.z)
         0.5714103921047806
-	
+
 > **`elements`**
 
 Return all four elements of the quaternion object. Result is not guaranteed to be a unit 4-vector.

--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -97,7 +97,8 @@ class Quaternion:
                 elif "array" in kwargs:
                     self.q = self._validate_number_sequence(kwargs["array"], 4)
                 elif "matrix" in kwargs:
-                    self.q = Quaternion._from_matrix(kwargs["matrix"]).q
+                    optional_args = {key: kwargs[key] for key in kwargs if key in ['rtol', 'atol']}
+                    self.q = Quaternion._from_matrix(kwargs["matrix"], **optional_args).q
                 else:
                     keys = sorted(kwargs.keys())
                     elements = [kwargs[kw] for kw in keys]
@@ -156,7 +157,7 @@ class Quaternion:
 
     # Initialise from matrix
     @classmethod
-    def _from_matrix(cls, matrix):
+    def _from_matrix(cls, matrix, **kwargs):
         """Initialise from matrix representation
 
         Create a Quaternion by specifying the 3x3 rotation or 4x4 transformation matrix
@@ -176,9 +177,9 @@ class Quaternion:
             raise ValueError("Invalid matrix shape: Input must be a 3x3 or 4x4 numpy array or matrix")
 
         # Check matrix properties
-        if not np.allclose(np.dot(R, R.conj().transpose()), np.eye(3)):
+        if not np.allclose(np.dot(R, R.conj().transpose()), np.eye(3), **kwargs):
             raise ValueError("Matrix must be orthogonal, i.e. its transpose should be its inverse")
-        if not np.isclose(np.linalg.det(R), 1.0):
+        if not np.isclose(np.linalg.det(R), 1.0, **kwargs):
             raise ValueError("Matrix must be special orthogonal i.e. its determinant must be +1.0")
 
         def decomposition_method(matrix):

--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -157,7 +157,7 @@ class Quaternion:
 
     # Initialise from matrix
     @classmethod
-    def _from_matrix(cls, matrix, **kwargs):
+    def _from_matrix(cls, matrix, rtol=1e-05, atol=1e-08):
         """Initialise from matrix representation
 
         Create a Quaternion by specifying the 3x3 rotation or 4x4 transformation matrix
@@ -177,9 +177,9 @@ class Quaternion:
             raise ValueError("Invalid matrix shape: Input must be a 3x3 or 4x4 numpy array or matrix")
 
         # Check matrix properties
-        if not np.allclose(np.dot(R, R.conj().transpose()), np.eye(3), **kwargs):
+        if not np.allclose(np.dot(R, R.conj().transpose()), np.eye(3), rtol=rtol, atol=atol):
             raise ValueError("Matrix must be orthogonal, i.e. its transpose should be its inverse")
-        if not np.isclose(np.linalg.det(R), 1.0, **kwargs):
+        if not np.isclose(np.linalg.det(R), 1.0, rtol=rtol, atol=atol):
             raise ValueError("Matrix must be special orthogonal i.e. its determinant must be +1.0")
 
         def decomposition_method(matrix):

--- a/pyquaternion/test/test_quaternion.py
+++ b/pyquaternion/test/test_quaternion.py
@@ -317,6 +317,29 @@ class TestQuaternionInitialisation(unittest.TestCase):
         with self.assertRaises(ValueError):
             q4 = Quaternion(matrix=R)
 
+    def test_init_from_explicit_matrix_with_optional_tolerance_arguments(self):
+        """
+            The matrix defined in this test is orthogonal was carefully crafted
+            such that it's orthogonal to a precision of 1e-07, but not to a precision
+            of 1e-08. The default value for numpy's atol function is 1e-08, but
+            developers should have the option to use a lower precision if they choose
+            to.
+
+            Reference: https://docs.scipy.org/doc/numpy/reference/generated/numpy.allclose.html
+        """
+        m = [[ 0.73297226, -0.16524626, -0.65988294, -0.07654548],
+             [ 0.13108627,  0.98617666, -0.10135052, -0.04878795],
+             [ 0.66750896, -0.01221443,  0.74450167, -0.05474513],
+             [ 0,          0,          0,          1,        ]]
+        npm = np.matrix(m)
+
+        with self.assertRaises(ValueError):
+            Quaternion(matrix=npm)
+
+        try:
+            Quaternion(matrix=npm, atol=1e-07)
+        except ValueError:
+            self.fail("Quaternion() raised ValueError unexpectedly!")
 
     def test_init_from_explicit_arrray(self):
         r = randomElements()


### PR DESCRIPTION
Changes:
- Optionally pass in the rtol and atol arguments from
  pyquaternion to numpys `allclose` and `isclose` functions
  when initializing a Quaternion from a matrix
- Add a unit test with and without optional args
  when initializing a Quaternion from a matrix

Initiliaizing a quaternion from a matrix raises a ValueError
if the provided matrix is not orthogonal. This is because
the default precision used by numpy's allclose function is
1e-08.

Developers should have an option to specify a lower precision
if they choose to and still use all of the utilities in this
library.