### PR TITLE
Remove implicit normalisation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -633,25 +633,27 @@ Get the instantaneous quaternion derivative representing a quaternion rotating a
 ## Integration
 > **`integrate(rate, timestep)`**
 
-Advance a time varying quaternion to its value at a time `timestep` in the future.
+Return a copy of a time varying quaternion at its value at a time `timestep` in the future.
 
-The Quaternion object will be modified to its future value. It is guaranteed to remain a unit quaternion.
 
 **Params:**
 
 * `rate` - numpy 3-array (or array-like) describing rotation rates about the global x, y and z axes respectively.
 * `timestep` - interval over which to integrate into the future. Assuming *now* is `T=0`, the integration occurs over the interval `T=0` to `T=timestep`. Smaller intervals are more accurate when `rate` changes over time.
 
+**Returns:** A unit quaternion describing the rotation rate
+
 **Note 1:** 
 This feature only makes sense when referring to a unit quaternion.
 Calling this method will use a normalised copy of the stored quaternion to perform the operation
+The returned object will also be normalised to unit length
 
 
 **Note 2:** The solution is in closed form given the assumption that `rate` is constant over the interval of length `timestep`. This algorithm is not an exact solution to the differential equation over any interval where the angular rates are not constant. It is a second order approximation, meaning the integral error contains terms proportional to `timestep ** 3` and higher powers.
 
 	>>> q = Quaternion() # null rotation
-	>>> q.integrate([2*pi, 0, 0], 0.25) # Rotate about x at 1 rotation per second
-	>>> q == Quaternion(axis=[1, 0, 0], angle=(pi/2))
+	>>> p = q.integrate([2*pi, 0, 0], 0.25) # Rotate about x at 1 rotation per second
+	>>> p == Quaternion(axis=[1, 0, 0], angle=(pi/2))
 	True
 	>>>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -392,6 +392,11 @@ Rotate a 3D vector by the rotation stored in the Quaternion object
 
 **Returns:** the rotated vector returned as the same type it was specified at input.
 
+**Note:** 
+This feature only makes sense when referring to a unit quaternion.
+Calling this method will use a normalised copy of the stored quaternion to perform the operation
+
+
 	rotated_tuple 		= my_quaternion.rotate((1, 0, 0)) # Returns a tuple
 	rotated_list  		= my_quaternion.rotate([1.0, 0.0, 0.0]) # Returns a list
 	rotated_array 		= my_quaternion.rotate(numpy.array([1.0, 0.0, 0.0])) # Returns a Numpy 3-array
@@ -552,7 +557,9 @@ This is a class method and is called as a method of the class itself rather than
 **Returns:**
 a new Quaternion object representing the interpolated rotation. This is guaranteed to be a unit quaternion.
 
-**Note:** This feature only makes sense when interpolating between unit quaternions (those lying on the unit radius hypersphere). Calling this method will implicitly normalise the endpoints to unit quaternions if they are not already unit length.
+**Note:** 
+This feature only makes sense when interpolating between unit quaternions (those lying on the unit radius hypersphere).
+Calling this method will use normalised copies of the the endpoints quaternions to perform the operation
 
 	q0 = Quaternion(axis=[1, 1, 1], angle=0.0)
 	q1 = Quaternion(axis=[1, 1, 1], angle=3.141592)
@@ -575,7 +582,10 @@ This is a class method and is called as a method of the class itself rather than
 **Yields:**
 a generator object iterating over a sequence of intermediate quaternion objects.
 
-**Note:** This feature only makes sense when interpolating between unit quaternions (those lying on the unit radius hypersphere). Calling this method will implicitly normalise the endpoints to unit quaternions if they are not already unit length.
+**Note:** 
+This feature only makes sense when referring to a unit quaternion.
+Calling this method will use a normalised copy of the stored quaternion to perform the operation
+
 
 	q0 = Quaternion(axis=[1, 1, 1], angle=0.0)
 	q1 = Quaternion(axis=[1, 1, 1], angle=2 * 3.141592 / 3)
@@ -615,7 +625,10 @@ The Quaternion object will be modified to its future value. It is guaranteed to 
 * `rate` - numpy 3-array (or array-like) describing rotation rates about the global x, y and z axes respectively.
 * `timestep` - interval over which to integrate into the future. Assuming *now* is `T=0`, the integration occurs over the interval `T=0` to `T=timestep`. Smaller intervals are more accurate when `rate` changes over time.
 
-**Note 1:** This feature only makes sense when referring to a unit quaternion. Calling this method will implicitly normalise the Quaternion object to a unit quaternion if it is not already one. Many quaternion integration algorithms will have unwanted scaling effects leading a quaternion object to become non-unit over time, thus the object is re-normalised with each call to `integrate()`. Because this method is often called very frequently (every `timestep` for realtime simulation) an optimised re-normalisation is performed. See `_fast_normalise()` for more info.
+**Note 1:** 
+This feature only makes sense when referring to a unit quaternion.
+Calling this method will use a normalised copy of the stored quaternion to perform the operation
+
 
 **Note 2:** The solution is in closed form given the assumption that `rate` is constant over the interval of length `timestep`. This algorithm is not an exact solution to the differential equation over any interval where the angular rates are not constant. It is a second order approximation, meaning the integral error contains terms proportional to `timestep ** 3` and higher powers.
 
@@ -640,7 +653,10 @@ Get the 3x3 rotation or 4x4 homogeneous transformation matrix equivalent of the 
 * `Quaternion.rotation_matrix` : a 3x3 orthogonal rotation matrix as a 3x3 Numpy array
 * `Quaternion.transformation_matrix` : a 4x4 homogeneous transformation matrix as a 4x4 Numpy array
 
-**Note 1:** This feature only makes sense when referring to a unit quaternion. Calling this method will implicitly normalise the Quaternion object to a unit quaternion if it is not already one.
+**Note 1:** 
+This feature only makes sense when referring to a unit quaternion.
+Calling this method will use a normalised copy of the stored quaternion to perform the operation
+
 
 **Note 2:** Both matrices and quaternions avoid the singularities and discontinuities involved with rotation in 3 dimensions by adding extra dimensions. This has the effect that different values could represent the same rotation, for example quaternion q and -q represent the same rotation. It is therefore possible that, when converting a rotation sequence, the output may jump between different but equivalent forms. This could cause problems where subsequent operations such as differentiation are done on this data. Programmers should be aware of this issue.
 
@@ -664,7 +680,10 @@ alternative `get_axis()` form, specifying the `undefined` keyword to return a ve
 
 **Returns:** a Numpy unit 3-vector describing the Quaternion object's axis of rotation.
 
-**Note 1:** This feature only makes sense when referring to a unit quaternion. Calling this method will implicitly normalise the Quaternion object to a unit quaternion if it is not already one.
+**Note 1:** 
+This feature only makes sense when referring to a unit quaternion.
+Calling this method will use a normalised copy of the stored quaternion to perform the operation
+
 
 **Note 2:** Both matrices and quaternions avoid the singularities and discontinuities involved with rotation in 3 dimensions by adding extra dimensions. This has the effect that different values could represent the same rotation, for example quaternion q and -q represent the same rotation. It is therefore possible that, when converting a rotation sequence to axis/angle representation, the output may jump between different but equivalent forms. This could cause problems where subsequent operations such as differentiation are done on this data. Programmers should be aware of this issue.
 
@@ -681,7 +700,9 @@ When a particular rotation describes a 180 degree rotation about an arbitrary ax
 
 **Returns:** a real number in the range (-pi:pi) describing the angle of rotation in radians about a Quaternion object's axis of rotation.
 
-**Note 1:** This feature only makes sense when referring to a unit quaternion. Calling this method will implicitly normalise the Quaternion object to a unit quaternion if it is not already one.
+**Note 1:** 
+This feature only makes sense when referring to a unit quaternion.
+Calling this method will use a normalised copy of the stored quaternion to perform the operation
 
 **Note 2:** Both matrices and quaternions avoid the singularities and discontinuities involved with rotation in 3 dimensions by adding extra dimensions. This has the effect that different values could represent the same rotation, for example quaternion q and -q represent the same rotation. It is therefore possible that, when converting a rotation sequence to axis/angle representation, the output may jump between different but equivalent forms. This could cause problems where subsequent operations such as differentiation are done on this data. Programmers should be aware of this issue.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -251,6 +251,7 @@ Either component (but not both) may be absent, `None` or empty, and will be assu
 Specify the angle (qualified as radians or degrees) for a rotation about an axis vector [x, y, z] to be described by the quaternion object.
 
 **Params**
+
 * `axis=ax` can be a sequence or numpy array containing 3 real numbers. It can have any magnitude except `0`.
 * `radians=rad` [optional] a real number, or a string representing a real number in radians.
 * `degrees=deg` [optional] a real number, or a string representing a real number in degrees.
@@ -379,6 +380,22 @@ A unit quaternion has a `norm` of 1.0
 
 	unit_quaternion = my_quaternion.normalised
 	unit_quaternion = my_quaternion.unit
+	
+> **`fast_normalised`**
+
+Get a unit quaternion (versor) copy of this Quaternion object.
+
+A unit quaternion has a `norm` of 1.0
+
+For performance, this method may use a Pade approximation to estimate the magnitude of the quaternion, avoiding a costly `sqrt()` calculation.
+The approximation is only performed where the it is most accurate (when the object to be normalise is already approximately of unit length), 
+otherwise, a full normalisation is performed.
+
+**Note:** A Quaternion representing zero i.e. `Quaternion(0, 0, 0, 0)` cannot be normalised. In this case, the returned object will remain zero.
+
+**Returns:** a new Quaternion object clone that is guaranteed to be very close to a unit quaternion *unless* the original object was zero, in which case the norm will remain zero.
+
+	unit_quaternion = my_quaternion.fast_normalised
 
 
 ## Rotation

--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -945,10 +945,8 @@ class Quaternion:
         return 0.5 * self * Quaternion(vector=rate)
 
     def integrate(self, rate, timestep):
-        """Advance a time varying quaternion to its value at a time `timestep` in the future.
-
-        The Quaternion object will be modified to its future value.
-        It is guaranteed to remain a unit quaternion.
+        """
+        Return a copy of a time varying quaternion at its value at a time `timestep` in the future.
 
         Params:
 
@@ -959,11 +957,12 @@ class Quaternion:
             `T=0` to `T=timestep`. Smaller intervals are more accurate when
             `rate` changes over time.
 
+        return: A unit Quaternion object describing the rotation at a time `timestep` in the future.
+
         Note:
             The solution is closed form given the assumption that `rate` is constant
             over the interval of length `timestep`.
         """
-        # TODO modify API to return a copy Quaternion object rather than mutate - this is a breaking change
         copy = self.fast_normalised
         rate = self.validate_number_sequence(rate, 3)
 
@@ -973,9 +972,10 @@ class Quaternion:
             axis = rotation_vector / rotation_norm
             angle = rotation_norm
             q2 = Quaternion(axis=axis, angle=angle)
-            self.q = (copy * q2).q
-            self._fast_normalise()
+            result = copy * q2
+            return result.fast_normalised
 
+        return Quaternion(copy.q)
 
     @property
     def rotation_matrix(self):

--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -658,7 +658,7 @@ class Quaternion:
         else:
             return a
 
-    @classmethod
+    @classmethodf
     def exp(cls, q):
         """Quaternion Exponential.
 

--- a/pyquaternion/test/test_quaternion.py
+++ b/pyquaternion/test/test_quaternion.py
@@ -40,10 +40,7 @@ from random import random
 
 import numpy as np
 
-import pyquaternion
-
-Quaternion = pyquaternion.Quaternion
-
+from pyquaternion import Quaternion
 
 ALMOST_EQUAL_TOLERANCE = 13
 
@@ -307,7 +304,7 @@ class TestQuaternionInitialisation(unittest.TestCase):
 
             np.testing.assert_almost_equal(v_prime_q2, v_prime_r, decimal=ALMOST_EQUAL_TOLERANCE)
 
-        R = np.matrix(np.eye(3))
+        R = np.eye(3)
         q3 = Quaternion(matrix=R)
         v_prime_q3 = q3.rotate(v)
         np.testing.assert_almost_equal(v, v_prime_q3, decimal=ALMOST_EQUAL_TOLERANCE)
@@ -1024,16 +1021,16 @@ class TestQuaternionFeatures(unittest.TestCase):
         v = [1, 0, 0] # test vector
         for dt in [0, 0.25, 0.5, 0.75, 1, 2, 10, 1e-10, random()*10]: # time step in seconds
             qt = Quaternion() # no rotation
-            qt.integrate(rotation_rate, dt)
+            qt_i = qt.integrate(rotation_rate, dt)
             q_truth = Quaternion(axis=[0,0,1], angle=dt*2*pi)
-            a = qt.rotate(v)
+            a = qt_i.rotate(v)
             b = q_truth.rotate(v)
             np.testing.assert_almost_equal(a, b, decimal=ALMOST_EQUAL_TOLERANCE)
-            self.assertTrue(qt.is_unit())
+            self.assertTrue(qt_i.is_unit())
         # Check integrate() is norm-preserving over many calls
         q = Quaternion()
         for i in range(1000):
-            q.integrate([pi, 0, 0], 0.001)
+            q = q.integrate([pi, 0, 0], 0.001)
         self.assertTrue(q.is_unit())
 
 

--- a/pyquaternion/test/test_quaternion.py
+++ b/pyquaternion/test/test_quaternion.py
@@ -937,9 +937,9 @@ class TestQuaternionFeatures(unittest.TestCase):
         self.assertEqual(pi/3, Quaternion.distance(q,p))
         q = Quaternion(scalar=1, vector=[1,1,1])
         p = Quaternion(scalar=-1, vector=[-1,-1,-1])
-        p._normalise()
-        q._normalise()
-        self.assertAlmostEqual(0, Quaternion.distance(q,p), places=8)
+        p_n = p.normalised
+        q_n = q.normalised
+        self.assertAlmostEqual(0, Quaternion.distance(q_n, p_n), places=8)
 
     def test_absolute_distance(self):
         q = Quaternion(scalar=0, vector=[1,0,0])
@@ -953,9 +953,9 @@ class TestQuaternionFeatures(unittest.TestCase):
         self.assertEqual((q+p).norm, Quaternion.absolute_distance(q,p))
         q = Quaternion(scalar=1, vector=[1,1,1])
         p = Quaternion(scalar=-1, vector=[-1,-1,-1])
-        p._normalise()
-        q._normalise()
-        self.assertAlmostEqual(0, Quaternion.absolute_distance(q,p), places=8)
+        p_n = p.normalised
+        q_n = q.normalised
+        self.assertAlmostEqual(0, Quaternion.absolute_distance(q_n, p_n), places=8)
 
     def test_sym_distance(self):
         q = Quaternion(scalar=0, vector=[1,0,0])
@@ -969,9 +969,9 @@ class TestQuaternionFeatures(unittest.TestCase):
         self.assertEqual(pi/2, Quaternion.sym_distance(q,p))
         q = Quaternion(scalar=1, vector=[1,1,1])
         p = Quaternion(scalar=-1, vector=[-1,-1,-1])
-        p._normalise()
-        q._normalise()
-        self.assertAlmostEqual(pi, Quaternion.sym_distance(q,p), places=8)
+        p_n = p.normalised
+        q_n = q.normalised
+        self.assertAlmostEqual(pi, Quaternion.sym_distance(q_n, p_n), places=8)
 
     def test_slerp(self):
         q1 = Quaternion(axis=[1, 0, 0], angle=0.0)


### PR DESCRIPTION
Resolves https://github.com/KieranWynn/pyquaternion/issues/39

Remove as many calls as possible to `Quaternion._normalise()` and `Quaternion._fast_normalise()` as these mutate the object and cause implicit side effects.

Updated docs to encourage the use of `Quaternion.normalised` and `Quaternion.fast_normalised` properties instead.

There is a notable breaking change here; the `integrate()` method whos previous interface assumes that the underlying object is mutated. This has been changed to return a new Quaternion object rather than mutating to avoid side effects. Docs have been updated.

Because this involves breaking changes, the targeted version will be 1.0