### PR TITLE
Fix casting error in trace_method

### DIFF
--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -227,7 +227,7 @@ class Quaternion:
                     t = 1 + m[0, 0] + m[1, 1] + m[2, 2]
                     q = [t,  m[1, 2]-m[2, 1],  m[2, 0]-m[0, 2],  m[0, 1]-m[1, 0]]
 
-            q = np.array(q)
+            q = np.array(q).astype('float64')
             q *= 0.5 / sqrt(t)
             return q
 


### PR DESCRIPTION
When a user supplies a matrix of type `int`, the following error is thrown:

```
>>> Quaternion(matrix=np.array([[1,0,0], [0,1,0], [0,0,1]]))
TypeError: Cannot cast ufunc multiply output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
```

This forces the incoming numpy array to be converted as `float64`.