### PR TITLE
not use np.matrix to fix PendingDeprecationWarning

### DIFF
--- a/pyquaternion/test/test_quaternion.py
+++ b/pyquaternion/test/test_quaternion.py
@@ -307,7 +307,7 @@ class TestQuaternionInitialisation(unittest.TestCase):
 
             np.testing.assert_almost_equal(v_prime_q2, v_prime_r, decimal=ALMOST_EQUAL_TOLERANCE)
 
-        R = np.matrix(np.eye(3))
+        R = np.eye(3)
         q3 = Quaternion(matrix=R)
         v_prime_q3 = q3.rotate(v)
         np.testing.assert_almost_equal(v, v_prime_q3, decimal=ALMOST_EQUAL_TOLERANCE)
@@ -331,7 +331,7 @@ class TestQuaternionInitialisation(unittest.TestCase):
              [ 0.13108627,  0.98617666, -0.10135052, -0.04878795],
              [ 0.66750896, -0.01221443,  0.74450167, -0.05474513],
              [ 0,          0,          0,          1,        ]]
-        npm = np.matrix(m)
+        npm = np.array(m)
 
         with self.assertRaises(ValueError):
             Quaternion(matrix=npm)


### PR DESCRIPTION
Under the followings environment, we can see PendingDeprecationWarning from numpy.

```
$ pip freeze
numpy==1.20.1
pyquaternion==0.9.9
```

```
$ python pyquaternion/test/test_quaternion.py
.....................................................pyquaternion/test/test_quaternion.py:310: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
  R = np.matrix(np.eye(3))
.pyquaternion/test/test_quaternion.py:334: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
  npm = np.matrix(m)
...............
----------------------------------------------------------------------
Ran 69 tests in 0.112s

OK
```

So, we should use ndarray instead of numpy.matrix.

ref. https://github.com/numpy/numpy/blob/master/numpy/matrixlib/defmatrix.py#L116-L121