### PR TITLE
Got a bit carried away adding preliminary support for numba =)

### DIFF
--- a/pyquaternion/numba_opt.py
+++ b/pyquaternion/numba_opt.py
@@ -1,7 +1,7 @@
 import functools
 __author__ = 'Alex Pyattaev'
 import os
-
+import numba.core.errors
 try:
 
     if 'NO_NUMBA' in os.environ:
@@ -17,9 +17,11 @@ try:
     int16 = numba.int16
     double = numba.double
     complex128 = numba.complex128
+    TypingError = numba.core.errors.TypingError
 except ImportError:
     numba = None
     numba_available = False
+    TypingError = TypeError
     int64 = int
     int16 = int
     double = float

--- a/pyquaternion/numba_opt.py
+++ b/pyquaternion/numba_opt.py
@@ -1,0 +1,40 @@
+import functools
+__author__ = 'Alex Pyattaev'
+import os
+
+try:
+
+    if 'NO_NUMBA' in os.environ:
+        raise ImportError("Numba is disabled")
+
+    import numba
+    import numba.experimental
+    numba_available = True
+    jit_hardcore = functools.partial(numba.jit, nopython=True, nogil=True, cache=True)
+    jit = functools.partial(numba.jit, forceobj=True, nopython=False, cache=True)
+    jitclass = numba.experimental.jitclass
+    int64 = numba.int64
+    int16 = numba.int16
+    double = numba.double
+    complex128 = numba.complex128
+except ImportError:
+    numba = None
+    numba_available = False
+    int64 = int
+    int16 = int
+    double = float
+    complex128 = complex
+
+    #define stub functions for Numba placeholders
+    def jit(f, *args, **kwargs):
+        return f
+
+    def jitclass(c, *args, **kwargs):
+        def x(cls):
+            return cls
+        return x
+
+    def jit_hardcore(f, *args, **kwargs):
+        return f
+
+

--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -1098,6 +1098,27 @@ class Quaternion:
         if angle_deg is not None:
             return np.deg2rad(angle_deg)
 
+    @jit
+    def swing_twist_decomp(self, axis):
+        """Perform a Swing*Twist decomposition of a Quaternion. This splits the
+        quaternion in two: one containing the rotation around axis (Twist), the
+        other containing the rotation around a vector parallel to axis (Swing).
+        Returns two quaternions: Swing, Twist.
+        source: https://github.com/CCP-NC/soprano/blob/master/soprano/utils.py
+        """
+
+        # Current rotation axis
+        ra = self.q[1:]
+        # Ensure that axis is normalised
+        axis_norm = axis / np.linalg.norm(axis)
+        # Projection of ra along the given axis
+        p = np.dot(ra, axis_norm) * axis_norm
+        # Create Twist
+        qin = np.array((self.q[0], p[0], p[1], p[2]))
+        twist = Quaternion(qin / _norm(qin))
+        # And Swing
+        swing = self * twist.conjugate
+        return swing, twist
 
 @jit_hardcore
 def _wrap_angle(theta):

--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -48,7 +48,7 @@ _EPS: float = np.finfo(float).eps * 4.0
 
 if numba_available:
     _spec_Quaternion = [
-        ('q', double[:]),  # array field spec for numba
+        ('q', double[::1]),  # array field spec for numba
     ]
 else:
     _spec_Quaternion = []

--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -31,14 +31,30 @@ SOFTWARE.
 quaternion.py - This file defines the core Quaternion class
 
 """
+import warnings
+from math import sqrt, pi, sin, cos, acos, atan2, exp, log
 
-from __future__ import absolute_import, division, print_function # Add compatibility for Python 2.7+
+try:
+    from math import tau
+except ImportError:
+    tau = pi * 2
 
-from math import sqrt, pi, sin, cos, asin, acos, atan2, exp, log
-from copy import deepcopy
-import numpy as np # Numpy is required for many vector operations
+from numbers import Number
+
+import numpy as np  # Numpy is required for many vector operations
+from .numba_opt import jitclass, jit_hardcore, jit, double, numba_available
+
+_EPS: float = np.finfo(float).eps * 4.0
+
+if numba_available:
+    _spec = [
+        ('q', double[:]),  # array field spec for numba
+    ]
+else:
+    _spec = []
 
 
+# @jitclass(_spec)
 class Quaternion:
     """Class to represent a 4-dimensional complex number or quaternion.
 
@@ -59,219 +75,94 @@ class Quaternion:
 
         """
         s = len(args)
-        if s == 0:
-            # No positional arguments supplied
-            if kwargs:
-                # Keyword arguments provided
-                if ("scalar" in kwargs) or ("vector" in kwargs):
-                    scalar = kwargs.get("scalar", 0.0)
-                    if scalar is None:
-                        scalar = 0.0
-                    else:
-                        scalar = float(scalar)
-
-                    vector = kwargs.get("vector", [])
-                    vector = self._validate_number_sequence(vector, 3)
-
-                    self.q = np.hstack((scalar, vector))
-                elif ("real" in kwargs) or ("imaginary" in kwargs):
-                    real = kwargs.get("real", 0.0)
-                    if real is None:
-                        real = 0.0
-                    else:
-                        real = float(real)
-
-                    imaginary = kwargs.get("imaginary", [])
-                    imaginary = self._validate_number_sequence(imaginary, 3)
-
-                    self.q = np.hstack((real, imaginary))
-                elif ("axis" in kwargs) or ("radians" in kwargs) or ("degrees" in kwargs) or ("angle" in kwargs):
-                    try:
-                        axis = self._validate_number_sequence(kwargs["axis"], 3)
-                    except KeyError:
-                        raise ValueError(
-                            "A valid rotation 'axis' parameter must be provided to describe a meaningful rotation."
-                        )
-                    angle = kwargs.get('radians') or self.to_radians(kwargs.get('degrees')) or kwargs.get('angle') or 0.0
-                    self.q = Quaternion._from_axis_angle(axis, angle).q
-                elif "array" in kwargs:
-                    self.q = self._validate_number_sequence(kwargs["array"], 4)
-                elif "matrix" in kwargs:
-                    optional_args = {key: kwargs[key] for key in kwargs if key in ['rtol', 'atol']}
-                    self.q = Quaternion._from_matrix(kwargs["matrix"], **optional_args).q
-                else:
-                    keys = sorted(kwargs.keys())
-                    elements = [kwargs[kw] for kw in keys]
-                    if len(elements) == 1:
-                        r = float(elements[0])
-                        self.q = np.array([r, 0.0, 0.0, 0.0])
-                    else:
-                        self.q = self._validate_number_sequence(elements, 4)
-
-            else:
+        if s == 0:  # No positional arguments supplied
+            if not kwargs:
                 # Default initialisation
                 self.q = np.array([1.0, 0.0, 0.0, 0.0])
+                return
+            # Keyword arguments provided
+            if ("scalar" in kwargs) or ("vector" in kwargs):
+                scalar = kwargs.get("scalar", 0.0)
+                scalar = 0.0 if scalar is None else float(scalar)
+                vector = kwargs.get("vector", np.zeros(3, dtype=float))
+                vector = _validate_number_sequence(vector, 3)
+
+                self.q = np.hstack((scalar, vector))
+            elif ("real" in kwargs) or ("imaginary" in kwargs):
+                real = kwargs.get("real", 0.0)
+                real = 0.0 if real is None else float(real)
+                imaginary = kwargs.get("imaginary", np.zeros(3, dtype=float))
+                imaginary = _validate_number_sequence(imaginary, 3)
+
+                self.q = np.hstack((real, imaginary))
+            elif ("axis" in kwargs) or ("radians" in kwargs) or ("degrees" in kwargs) or ("angle" in kwargs):
+                try:
+                    axis = _validate_number_sequence(kwargs["axis"], 3)
+                except KeyError:
+                    raise ValueError(
+                        "A valid rotation 'axis' parameter must be provided to describe a meaningful rotation."
+                    )
+                angle = kwargs.get('radians') or np.deg2rad(kwargs.get('degrees', 0.0)) or kwargs.get('angle', 0.0)
+                self.q = _from_axis_angle(axis, angle)
+            elif "array" in kwargs:
+                self.q = _validate_number_sequence(kwargs["array"], 4)
+            elif "matrix" in kwargs:
+                optional_args = {key: kwargs[key] for key in kwargs if key in ('rtol', 'atol')}
+                self.q = _from_matrix(kwargs["matrix"], **optional_args)
+            else:
+                keys = sorted(kwargs.keys())
+                elements = [kwargs[kw] for kw in keys]
+                if len(elements) == 1:
+                    r = float(elements[0])
+                    self.q = np.array([r, 0.0, 0.0, 0.0])
+                else:
+                    self.q = _validate_number_sequence(elements, 4)
+
         elif s == 1:
             # Single positional argument supplied
             if isinstance(args[0], Quaternion):
                 self.q = args[0].q
                 return
-            if args[0] is None:
-                raise TypeError("Object cannot be initialised from {}".format(type(args[0])))
-            try:
-                r = float(args[0])
-                self.q = np.array([r, 0.0, 0.0, 0.0])
-                return
-            except TypeError:
-                pass  # If the single argument is not scalar, it should be a sequence
 
-            self.q = self._validate_number_sequence(args[0], 4)
+            if args[0] is None:
+                raise TypeError("Object cannot be initialised from None")
+
+            if isinstance(args[0], Number):
+                self.q = np.array([float(args[0]), 0.0, 0.0, 0.0])
+                return
+
+            if isinstance(args[0], str):
+                raise ValueError("Can not initialize quaternions from strings")
+
+            self.q = _validate_number_sequence(args[0], 4)
             return
 
         else:
             # More than one positional argument supplied
-            self.q = self._validate_number_sequence(args, 4)
+            self.q = _validate_number_sequence(args, 4)
 
     def __hash__(self):
         return hash(tuple(self.q))
 
-    def _validate_number_sequence(self, seq, n):
-        """Validate a sequence to be of a certain length and ensure it's a numpy array of floats.
-
-        Raises:
-            ValueError: Invalid length or non-numeric value
-        """
-        if seq is None:
-            return np.zeros(n)
-        if len(seq) == n:
-            try:
-                l = [float(e) for e in seq]
-            except ValueError:
-                raise ValueError("One or more elements in sequence <{!r}> cannot be interpreted as a real number".format(seq))
-            else:
-                return np.asarray(l)
-        elif len(seq) == 0:
-            return np.zeros(n)
-        else:
-            raise ValueError("Unexpected number of elements in sequence. Got: {}, Expected: {}.".format(len(seq), n))
-
-    # Initialise from matrix
-    @classmethod
-    def _from_matrix(cls, matrix, rtol=1e-05, atol=1e-08):
-        """Initialise from matrix representation
-
-        Create a Quaternion by specifying the 3x3 rotation or 4x4 transformation matrix
-        (as a numpy array) from which the quaternion's rotation should be created.
-
-        """
-        try:
-            shape = matrix.shape
-        except AttributeError:
-            raise TypeError("Invalid matrix type: Input must be a 3x3 or 4x4 numpy array or matrix")
-
-        if shape == (3, 3):
-            R = matrix
-        elif shape == (4, 4):
-            R = matrix[:-1][:,:-1] # Upper left 3x3 sub-matrix
-        else:
-            raise ValueError("Invalid matrix shape: Input must be a 3x3 or 4x4 numpy array or matrix")
-
-        # Check matrix properties
-        if not np.allclose(np.dot(R, R.conj().transpose()), np.eye(3), rtol=rtol, atol=atol):
-            raise ValueError("Matrix must be orthogonal, i.e. its transpose should be its inverse")
-        if not np.isclose(np.linalg.det(R), 1.0, rtol=rtol, atol=atol):
-            raise ValueError("Matrix must be special orthogonal i.e. its determinant must be +1.0")
-
-        def decomposition_method(matrix):
-            """ Method supposedly able to deal with non-orthogonal matrices - NON-FUNCTIONAL!
-            Based on this method: http://arc.aiaa.org/doi/abs/10.2514/2.4654
-            """
-            x, y, z = 0, 1, 2 # indices
-            K = np.array([
-                [R[x, x]-R[y, y]-R[z, z],  R[y, x]+R[x, y],           R[z, x]+R[x, z],           R[y, z]-R[z, y]],
-                [R[y, x]+R[x, y],          R[y, y]-R[x, x]-R[z, z],   R[z, y]+R[y, z],           R[z, x]-R[x, z]],
-                [R[z, x]+R[x, z],          R[z, y]+R[y, z],           R[z, z]-R[x, x]-R[y, y],   R[x, y]-R[y, x]],
-                [R[y, z]-R[z, y],          R[z, x]-R[x, z],           R[x, y]-R[y, x],           R[x, x]+R[y, y]+R[z, z]]
-            ])
-            K = K / 3.0
-
-            e_vals, e_vecs = np.linalg.eig(K)
-            print('Eigenvalues:', e_vals)
-            print('Eigenvectors:', e_vecs)
-            max_index = np.argmax(e_vals)
-            principal_component = e_vecs[max_index]
-            return principal_component
-
-        def trace_method(matrix):
-            """
-            This code uses a modification of the algorithm described in:
-            https://d3cw3dd2w32x2b.cloudfront.net/wp-content/uploads/2015/01/matrix-to-quat.pdf
-            which is itself based on the method described here:
-            http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/
-
-            Altered to work with the column vector convention instead of row vectors
-            """
-            m = matrix.conj().transpose() # This method assumes row-vector and postmultiplication of that vector
-            if m[2, 2] < 0:
-                if m[0, 0] > m[1, 1]:
-                    t = 1 + m[0, 0] - m[1, 1] - m[2, 2]
-                    q = [m[1, 2]-m[2, 1],  t,  m[0, 1]+m[1, 0],  m[2, 0]+m[0, 2]]
-                else:
-                    t = 1 - m[0, 0] + m[1, 1] - m[2, 2]
-                    q = [m[2, 0]-m[0, 2],  m[0, 1]+m[1, 0],  t,  m[1, 2]+m[2, 1]]
-            else:
-                if m[0, 0] < -m[1, 1]:
-                    t = 1 - m[0, 0] - m[1, 1] + m[2, 2]
-                    q = [m[0, 1]-m[1, 0],  m[2, 0]+m[0, 2],  m[1, 2]+m[2, 1],  t]
-                else:
-                    t = 1 + m[0, 0] + m[1, 1] + m[2, 2]
-                    q = [t,  m[1, 2]-m[2, 1],  m[2, 0]-m[0, 2],  m[0, 1]-m[1, 0]]
-
-            q = np.array(q).astype('float64')
-            q *= 0.5 / sqrt(t)
-            return q
-
-        return cls(array=trace_method(R))
-
-    # Initialise from axis-angle
-    @classmethod
-    def _from_axis_angle(cls, axis, angle):
-        """Initialise from axis and angle representation
-
-        Create a Quaternion by specifying the 3-vector rotation axis and rotation
-        angle (in radians) from which the quaternion's rotation should be created.
-
-        Params:
-            axis: a valid numpy 3-vector
-            angle: a real valued angle in radians
-        """
-        mag_sq = np.dot(axis, axis)
-        if mag_sq == 0.0:
-            raise ZeroDivisionError("Provided rotation axis has no length")
-        # Ensure axis is in unit vector form
-        if (abs(1.0 - mag_sq) > 1e-12):
-            axis = axis / sqrt(mag_sq)
-        theta = angle / 2.0
-        r = cos(theta)
-        i = axis * sin(theta)
-
-        return cls(r, i[0], i[1], i[2])
-
-    @classmethod
-    def random(cls):
+    @staticmethod
+    @jit
+    def random(randv=None):
         """Generate a random unit quaternion.
 
         Uniformly distributed across the rotation space
         As per: http://planning.cs.uiuc.edu/node198.html
         """
-        r1, r2, r3 = np.random.random(3)
+        if randv is None:
+            r1, r2, r3 = np.random.random(3)
+        else:
+            r1, r2, r3 = randv
+        rr1 = sqrt(1.0 - r1)
+        rr2 = sqrt(r1)
 
-        q1 = sqrt(1.0 - r1) * (sin(2 * pi * r2))
-        q2 = sqrt(1.0 - r1) * (cos(2 * pi * r2))
-        q3 = sqrt(r1)       * (sin(2 * pi * r3))
-        q4 = sqrt(r1)       * (cos(2 * pi * r3))
-
-        return cls(q1, q2, q3, q4)
+        t1 = tau * r1
+        t2 = tau * r2
+        return Quaternion(array=np.array([cos(t2) * rr2, sin(t1) * rr1,
+                                          cos(t1) * rr1, sin(t2) * rr2]))
 
     # Representation
     def __str__(self):
@@ -293,14 +184,14 @@ class Quaternion:
         The syntax for `format_spec` mirrors that of the built in format specifiers for floating point types.
         Check out the official Python [format specification mini-language](https://docs.python.org/3.4/library/string.html#formatspec) for details.
         """
-        if formatstr.strip() == '': # Defualt behaviour mirrors self.__str__()
+        if formatstr.strip() == '':  # Defualt behaviour mirrors self.__str__()
             formatstr = '+.3f'
 
         string = \
-            "{:" + formatstr +"} "  + \
-            "{:" + formatstr +"}i " + \
-            "{:" + formatstr +"}j " + \
-            "{:" + formatstr +"}k"
+            "{:" + formatstr + "} " + \
+            "{:" + formatstr + "}i " + \
+            "{:" + formatstr + "}j " + \
+            "{:" + formatstr + "}k"
         return string.format(self.q[0], self.q[1], self.q[2], self.q[3])
 
     # Type Conversion
@@ -332,13 +223,13 @@ class Quaternion:
         return complex(self.q[0], self.q[1])
 
     def __bool__(self):
-        return not (self == Quaternion(0.0))
+        return not (self == _Q0)
 
     def __nonzero__(self):
-        return not (self == Quaternion(0.0))
+        return not (self == _Q0)
 
     def __invert__(self):
-        return (self == Quaternion(0.0))
+        return self == _Q0
 
     # Comparison
     def __eq__(self, other):
@@ -351,13 +242,14 @@ class Quaternion:
             try:
                 isEqual = np.allclose(self.q, other.q, rtol=r_tol, atol=a_tol)
             except AttributeError:
-                raise AttributeError("Error in internal quaternion representation means it cannot be compared like a numpy array.")
+                raise AttributeError(
+                    "Error in internal quaternion representation means it cannot be compared like a numpy array.")
             return isEqual
         return self.__eq__(self.__class__(other))
 
     # Negation
     def __neg__(self):
-        return self.__class__(array= -self.q)
+        return self.__class__(array=-self.q)
 
     # Absolute value
     def __abs__(self):
@@ -369,19 +261,24 @@ class Quaternion:
             return self.__class__(array=self.q + other.q)
         return self + self.__class__(other)
 
+    @jit
     def __iadd__(self, other):
-        return self + other
+        return self.__add__(other)
 
+    @jit
     def __radd__(self, other):
-        return self + other
+        return self.__add__(other)
 
     # Subtraction
+    @jit
     def __sub__(self, other):
         return self + (-other)
 
+    @jit
     def __isub__(self, other):
         return self + (-other)
 
+    @jit
     def __rsub__(self, other):
         return -(self - other)
 
@@ -391,50 +288,59 @@ class Quaternion:
             return self.__class__(array=np.dot(self._q_matrix(), other.q))
         return self * self.__class__(other)
 
+    @jit
     def __imul__(self, other):
         return self * other
 
+    @jit
     def __rmul__(self, other):
         return self.__class__(other) * self
 
+    @jit
     def __matmul__(self, other):
         if isinstance(other, Quaternion):
             return self.q.__matmul__(other.q)
         return self.__matmul__(self.__class__(other))
 
+    @jit
     def __imatmul__(self, other):
         return self.__matmul__(other)
 
+    @jit
     def __rmatmul__(self, other):
         return self.__class__(other).__matmul__(self)
 
     # Division
     def __div__(self, other):
         if isinstance(other, Quaternion):
-            if other == self.__class__(0.0):
+            if other == _Q0:
                 raise ZeroDivisionError("Quaternion divisor must be non-zero")
             return self * other.inverse
-        return self.__div__(self.__class__(other))
+        return self.__div__(Quaternion(other))
 
+    @jit
     def __idiv__(self, other):
         return self.__div__(other)
 
+    @jit
     def __rdiv__(self, other):
         return self.__class__(other) * self.inverse
 
+    @jit
     def __truediv__(self, other):
         return self.__div__(other)
 
+    @jit
     def __itruediv__(self, other):
         return self.__idiv__(other)
 
+    @jit
     def __rtruediv__(self, other):
         return self.__rdiv__(other)
 
-    # Exponentiation
-    def __pow__(self, exponent):
+    def __pow__(self, exponent):  # Exponentiation
         # source: https://en.wikipedia.org/wiki/Quaternion#Exponential.2C_logarithm.2C_and_power
-        exponent = float(exponent) # Explicitly reject non-real exponents
+        exponent = float(exponent)  # Explicitly reject non-real exponents
         norm = self.norm
         if norm > 0.0:
             try:
@@ -442,19 +348,24 @@ class Quaternion:
             except ZeroDivisionError:
                 # quaternion is a real number (no vector or imaginary part)
                 return Quaternion(scalar=self.scalar ** exponent)
-            return (self.norm ** exponent) * Quaternion(scalar=cos(exponent * theta), vector=(n * sin(exponent * theta)))
+            return (self.norm ** exponent) * Quaternion(scalar=cos(exponent * theta),
+                                                        vector=(n * sin(exponent * theta)))
         return Quaternion(self)
 
+    @jit
     def __ipow__(self, other):
-        return self ** other
+        return self.__pow__(other)
 
+    @jit
     def __rpow__(self, other):
         return other ** float(self)
 
     # Quaternion Features
+    @jit
     def _vector_conjugate(self):
         return np.hstack((self.q[0], -self.q[1:4]))
 
+    @jit
     def _sum_of_squares(self):
         return np.dot(self.q, self.q)
 
@@ -499,16 +410,24 @@ class Quaternion:
 
     @property
     def magnitude(self):
-        return self.norm
+        """L2 norm of the quaternion 4-vector.
+
+        This should be 1.0 for a unit quaternion (versor)
+        Slow but accurate. If speed is a concern, consider using _fast_normalise() instead
+
+        Returns:
+            A scalar real number representing the square root of the sum of the squares of the elements of the quaternion.
+        """
+        mag_squared = self._sum_of_squares()
+        return sqrt(mag_squared)
 
     def _normalise(self):
         """Object is guaranteed to be a unit quaternion after calling this
         operation UNLESS the object is equivalent to Quaternion(0)
         """
-        if not self.is_unit():
-            n = self.norm
-            if n > 0:
-                self.q = self.q / n
+        n = self.norm
+        if n > 0:
+            self.q = self.q / n
 
     def _fast_normalise(self):
         """Normalise the object to a unit quaternion using a fast approximation method if appropriate.
@@ -516,16 +435,15 @@ class Quaternion:
         Object is guaranteed to be a quaternion of approximately unit length
         after calling this operation UNLESS the object is equivalent to Quaternion(0)
         """
-        if not self.is_unit():
-            mag_squared = np.dot(self.q, self.q)
-            if (mag_squared == 0):
-                return
-            if (abs(1.0 - mag_squared) < 2.107342e-08):
-                mag =  ((1.0 + mag_squared) / 2.0) # More efficient. Pade approximation valid if error is small
-            else:
-                mag =  sqrt(mag_squared) # Error is too big, take the performance hit to calculate the square root properly
+        mag_squared = np.dot(self.q, self.q)
+        if mag_squared == 0:
+            return
+        if abs(1.0 - mag_squared) < 2.107342e-08:
+            mag = ((1.0 + mag_squared) / 2.0)  # More efficient. Pade approximation valid if error is small
+        else:  # Error is too big, take the performance hit to calculate the square root properly
+            mag = sqrt(mag_squared)
 
-            self.q = self.q / mag
+        self.q = self.q / mag
 
     @property
     def normalised(self):
@@ -542,14 +460,14 @@ class Quaternion:
 
     @property
     def polar_unit_vector(self):
-        vector_length = np.linalg.norm(self.vector)
+        vector_length = _norm(self.vector)
         if vector_length <= 0.0:
             raise ZeroDivisionError('Quaternion is pure real and does not have a unique unit vector')
         return self.vector / vector_length
 
     @property
     def polar_angle(self):
-         return acos(self.scalar / self.norm)
+        return acos(self.scalar / self.norm)
 
     @property
     def polar_decomposition(self):
@@ -566,7 +484,8 @@ class Quaternion:
     def unit(self):
         return self.normalised
 
-    def is_unit(self, tolerance=1e-14):
+    @jit
+    def is_unit(self, tolerance=_EPS):
         """Determine whether the quaternion is of unit length to within a specified tolerance value.
 
         Params:
@@ -575,26 +494,30 @@ class Quaternion:
         Returns:
             `True` if the Quaternion object is of unit length to within the specified tolerance value. `False` otherwise.
         """
-        return abs(1.0 - self._sum_of_squares()) < tolerance # if _sum_of_squares is 1, norm is 1. This saves a call to sqrt()
+        # if _sum_of_squares is 1, norm is 1. This saves a call to sqrt()
+        return abs(1.0 - self._sum_of_squares()) < tolerance
 
+    @jit
     def _q_matrix(self):
         """Matrix representation of quaternion for multiplication purposes.
         """
         return np.array([
             [self.q[0], -self.q[1], -self.q[2], -self.q[3]],
-            [self.q[1],  self.q[0], -self.q[3],  self.q[2]],
-            [self.q[2],  self.q[3],  self.q[0], -self.q[1]],
-            [self.q[3], -self.q[2],  self.q[1],  self.q[0]]])
+            [self.q[1], self.q[0], -self.q[3], self.q[2]],
+            [self.q[2], self.q[3], self.q[0], -self.q[1]],
+            [self.q[3], -self.q[2], self.q[1], self.q[0]]])
 
+    @jit
     def _q_bar_matrix(self):
         """Matrix representation of quaternion for multiplication purposes.
         """
         return np.array([
             [self.q[0], -self.q[1], -self.q[2], -self.q[3]],
-            [self.q[1],  self.q[0],  self.q[3], -self.q[2]],
-            [self.q[2], -self.q[3],  self.q[0],  self.q[1]],
-            [self.q[3],  self.q[2], -self.q[1],  self.q[0]]])
+            [self.q[1], self.q[0], self.q[3], -self.q[2]],
+            [self.q[2], -self.q[3], self.q[0], self.q[1]],
+            [self.q[3], self.q[2], -self.q[1], self.q[0]]])
 
+    @jit
     def _rotate_quaternion(self, q):
         """Rotate a quaternion vector using the stored rotation.
 
@@ -637,14 +560,15 @@ class Quaternion:
         else:
             return a
 
-    @classmethod
-    def exp(cls, q):
+    @staticmethod
+    def exp(q, tolerance=_EPS):
         """Quaternion Exponential.
 
         Find the exponential of a quaternion amount.
 
         Params:
              q: the input quaternion/argument as a Quaternion object.
+             tolerance: numeric tolerance for null values
 
         Returns:
              A quaternion amount representing the exp(q). See [Source](https://math.stackexchange.com/questions/1030737/exponential-function-of-quaternion-derivation for more information and mathematical background).
@@ -652,43 +576,42 @@ class Quaternion:
         Note:
              The method can compute the exponential of any quaternion.
         """
-        tolerance = 1e-17
-        v_norm = np.linalg.norm(q.vector)
+        v_norm = _norm(q.vector)
         vec = q.vector
         if v_norm > tolerance:
             vec = vec / v_norm
         magnitude = exp(q.scalar)
-        return Quaternion(scalar = magnitude * cos(v_norm), vector = magnitude * sin(v_norm) * vec)
+        return Quaternion(scalar=magnitude * cos(v_norm), vector=magnitude * sin(v_norm) * vec)
 
-    @classmethod
-    def log(cls, q):
+    @staticmethod
+    def log(q, tolerance=_EPS):
         """Quaternion Logarithm.
 
         Find the logarithm of a quaternion amount.
 
         Params:
              q: the input quaternion/argument as a Quaternion object.
-
+             tolerance: numeric tolerance for null values
         Returns:
              A quaternion amount representing log(q) := (log(|q|), v/|v|acos(w/|q|)).
 
         Note:
             The method computes the logarithm of general quaternions. See [Source](https://math.stackexchange.com/questions/2552/the-logarithm-of-quaternion/2554#2554) for more details.
         """
-        v_norm = np.linalg.norm(q.vector)
+        v_norm = _norm(q.vector)
         q_norm = q.norm
-        tolerance = 1e-17
+
         if q_norm < tolerance:
             # 0 quaternion - undefined
-            return Quaternion(scalar=-float('inf'), vector=float('nan')*q.vector)
+            return Quaternion(scalar=-np.inf, vector=np.NAN * q.vector)
         if v_norm < tolerance:
             # real quaternions - no imaginary part
-            return Quaternion(scalar=log(q_norm), vector=[0, 0, 0])
+            return Quaternion(scalar=log(q_norm), vector=np.zeros(3))
         vec = q.vector / v_norm
-        return Quaternion(scalar=log(q_norm), vector=acos(q.scalar/q_norm)*vec)
+        return Quaternion(scalar=log(q_norm), vector=acos(q.scalar / q_norm) * vec)
 
-    @classmethod
-    def exp_map(cls, q, eta):
+    @staticmethod
+    def exp_map(q, eta):
         """Quaternion exponential map.
 
         Find the exponential map on the Riemannian manifold described
@@ -709,8 +632,8 @@ class Quaternion:
         """
         return q * Quaternion.exp(eta)
 
-    @classmethod
-    def sym_exp_map(cls, q, eta):
+    @staticmethod
+    def sym_exp_map(q, eta):
         """Quaternion symmetrized exponential map.
 
         Find the symmetrized exponential map on the quaternion Riemannian
@@ -731,8 +654,8 @@ class Quaternion:
         sqrt_q = q ** 0.5
         return sqrt_q * Quaternion.exp(eta) * sqrt_q
 
-    @classmethod
-    def log_map(cls, q, p):
+    @staticmethod
+    def log_map(q, p):
         """Quaternion logarithm map.
 
         Find the logarithm map on the quaternion Riemannian manifold.
@@ -748,8 +671,8 @@ class Quaternion:
         """
         return Quaternion.log(q.inverse * p)
 
-    @classmethod
-    def sym_log_map(cls, q, p):
+    @staticmethod
+    def sym_log_map(q, p):
         """Quaternion symmetrized logarithm map.
 
         Find the symmetrized logarithm map on the quaternion Riemannian manifold.
@@ -768,8 +691,8 @@ class Quaternion:
         inv_sqrt_q = (q ** (-0.5))
         return Quaternion.log(inv_sqrt_q * p * inv_sqrt_q)
 
-    @classmethod
-    def absolute_distance(cls, q0, q1):
+    @staticmethod
+    def absolute_distance(q0, q1):
         """Quaternion absolute distance.
 
         Find the distance between two quaternions accounting for the sign ambiguity.
@@ -788,16 +711,16 @@ class Quaternion:
            It is thus a good indicator for rotation similarities.
         """
         q0_minus_q1 = q0 - q1
-        q0_plus_q1  = q0 + q1
+        q0_plus_q1 = q0 + q1
         d_minus = q0_minus_q1.norm
-        d_plus  = q0_plus_q1.norm
+        d_plus = q0_plus_q1.norm
         if d_minus < d_plus:
             return d_minus
         else:
             return d_plus
 
-    @classmethod
-    def distance(cls, q0, q1):
+    @staticmethod
+    def distance(q0, q1):
         """Quaternion intrinsic distance.
 
         Find the intrinsic geodesic distance between q0 and q1.
@@ -818,8 +741,8 @@ class Quaternion:
         q = Quaternion.log_map(q0, q1)
         return q.norm
 
-    @classmethod
-    def sym_distance(cls, q0, q1):
+    @staticmethod
+    def sym_distance(q0, q1):
         """Quaternion symmetrized distance.
 
         Find the intrinsic symmetrized geodesic distance between q0 and q1.
@@ -843,8 +766,8 @@ class Quaternion:
         q = Quaternion.sym_log_map(q0, q1)
         return q.norm
 
-    @classmethod
-    def slerp(cls, q0, q1, amount=0.5):
+    @staticmethod
+    def slerp(q0, q1, amount=0.5):
         """Spherical Linear Interpolation between quaternions.
         Implemented as described in https://en.wikipedia.org/wiki/Slerp
 
@@ -900,8 +823,8 @@ class Quaternion:
         qr._fast_normalise()
         return qr
 
-    @classmethod
-    def intermediates(cls, q0, q1, n, include_endpoints=False):
+    @staticmethod
+    def intermediates(q0, q1, n, include_endpoints=False):
         """Generator method to get an iterable sequence of `n` evenly spaced quaternion
         rotations between any two existing quaternion endpoints lying on the unit
         radius hypersphere.
@@ -931,7 +854,7 @@ class Quaternion:
         else:
             steps = [i * step_size for i in range(1, n + 1)]
         for step in steps:
-            yield cls.slerp(q0, q1, step)
+            yield Quaternion.slerp(q0, q1, step)
 
     def derivative(self, rate):
         """Get the instantaneous quaternion derivative representing a quaternion rotating at a 3D rate vector `rate`
@@ -942,9 +865,10 @@ class Quaternion:
         Returns:
             A unit quaternion describing the rotation rate
         """
-        rate = self._validate_number_sequence(rate, 3)
+        rate = _validate_number_sequence(rate, 3)
         return 0.5 * self * Quaternion(vector=rate)
 
+    @jit
     def integrate(self, rate, timestep):
         """Advance a time varying quaternion to its value at a time `timestep` in the future.
 
@@ -965,17 +889,16 @@ class Quaternion:
             over the interval of length `timestep`.
         """
         self._fast_normalise()
-        rate = self._validate_number_sequence(rate, 3)
+        rate = _validate_number_sequence(rate, 3)
 
         rotation_vector = rate * timestep
-        rotation_norm = np.linalg.norm(rotation_vector)
+        rotation_norm = _norm(rotation_vector)
         if rotation_norm > 0:
             axis = rotation_vector / rotation_norm
             angle = rotation_norm
             q2 = Quaternion(axis=axis, angle=angle)
             self.q = (self * q2).q
             self._fast_normalise()
-
 
     @property
     def rotation_matrix(self):
@@ -1007,6 +930,7 @@ class Quaternion:
         return np.vstack([Rt, np.array([0.0, 0.0, 0.0, 1.0])])
 
     @property
+    @jit
     def yaw_pitch_roll(self):
         """Get the equivalent yaw-pitch-roll angles aka. intrinsic Tait-Bryan angles following the z-y'-x'' convention
 
@@ -1023,22 +947,12 @@ class Quaternion:
 
         self._normalise()
         yaw = np.arctan2(2 * (self.q[0] * self.q[3] - self.q[1] * self.q[2]),
-            1 - 2 * (self.q[2] ** 2 + self.q[3] ** 2))
+                         1 - 2 * (self.q[2] ** 2 + self.q[3] ** 2))
         pitch = np.arcsin(2 * (self.q[0] * self.q[2] + self.q[3] * self.q[1]))
         roll = np.arctan2(2 * (self.q[0] * self.q[1] - self.q[2] * self.q[3]),
-            1 - 2 * (self.q[1] ** 2 + self.q[2] ** 2))
+                          1 - 2 * (self.q[1] ** 2 + self.q[2] ** 2))
 
         return yaw, pitch, roll
-
-    def _wrap_angle(self, theta):
-        """Helper method: Wrap any angle to lie between -pi and pi
-
-        Odd multiples of pi are wrapped to +pi (as opposed to -pi)
-        """
-        result = ((theta + pi) % (2 * pi)) - pi
-        if result == -pi:
-            result = pi
-        return result
 
     def get_axis(self, undefined=np.zeros(3)):
         """Get the axis or vector about which the quaternion rotation occurs
@@ -1061,7 +975,7 @@ class Quaternion:
         """
         tolerance = 1e-17
         self._normalise()
-        norm = np.linalg.norm(self.vector)
+        norm = _norm(self.vector)
         if norm < tolerance:
             # Here there are an infinite set of possible axes, use what has been specified as an undefined axis.
             return undefined
@@ -1093,12 +1007,12 @@ class Quaternion:
             Calling this method will implicitly normalise the Quaternion object to a unit quaternion if it is not already one.
         """
         self._normalise()
-        norm = np.linalg.norm(self.vector)
-        return self._wrap_angle(2.0 * atan2(norm, self.scalar))
+        norm = _norm(self.vector)
+        return _wrap_angle(2.0 * atan2(norm, self.scalar))
 
     @property
     def degrees(self):
-        return self.to_degrees(self.angle)
+        return np.rad2deg(self.angle)
 
     @property
     def radians(self):
@@ -1168,16 +1082,180 @@ class Quaternion:
         return result
 
     def __deepcopy__(self, memo):
-        result = self.__class__(deepcopy(self.q, memo))
+        result = self.__class__(np.copy(self.q))
         memo[id(self)] = result
         return result
 
     @staticmethod
     def to_degrees(angle_rad):
+        warnings.warn("Use numpy rad2deg", DeprecationWarning)
         if angle_rad is not None:
-            return float(angle_rad) / pi * 180.0
+            return np.rad2deg(angle_rad)
 
     @staticmethod
     def to_radians(angle_deg):
+        warnings.warn("Use numpy deg2rad", DeprecationWarning)
         if angle_deg is not None:
-            return float(angle_deg) / 180.0 * pi
+            return np.deg2rad(angle_deg)
+
+
+@jit_hardcore
+def _wrap_angle(theta):
+    """Helper method: Wrap any angle to lie between -pi and pi
+
+    Odd multiples of pi are wrapped to +pi (as opposed to -pi)
+    """
+    return ((-theta + pi) % (tau) - pi) * -1.0
+
+
+@jit_hardcore
+def _decomposition_method(R: np.ndarray) -> np.ndarray:
+    """ Method supposedly able to deal with non-orthogonal matrices - NON-FUNCTIONAL!
+    Based on this method: http://arc.aiaa.org/doi/abs/10.2514/2.4654
+    """
+    x, y, z = 0, 1, 2  # indices
+    K = np.array([
+        [R[x, x] - R[y, y] - R[z, z], R[y, x] + R[x, y], R[z, x] + R[x, z], R[y, z] - R[z, y]],
+        [R[y, x] + R[x, y], R[y, y] - R[x, x] - R[z, z], R[z, y] + R[y, z], R[z, x] - R[x, z]],
+        [R[z, x] + R[x, z], R[z, y] + R[y, z], R[z, z] - R[x, x] - R[y, y], R[x, y] - R[y, x]],
+        [R[y, z] - R[z, y], R[z, x] - R[x, z], R[x, y] - R[y, x], R[x, x] + R[y, y] + R[z, z]]
+    ])
+    K = K / 3.0
+
+    e_vals, e_vecs = np.linalg.eig(K)
+    print('Eigenvalues:', e_vals)
+    print('Eigenvectors:', e_vecs)
+    max_index = np.argmax(e_vals)
+    principal_component = e_vecs[max_index]
+    return principal_component
+
+
+@jit_hardcore
+def _trace_method(matrix: np.ndarray) -> np.ndarray:
+    """
+    This code uses a modification of the algorithm described in:
+    https://d3cw3dd2w32x2b.cloudfront.net/wp-content/uploads/2015/01/matrix-to-quat.pdf
+    which is itself based on the method described here:
+    http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/
+
+    Altered to work with the column vector convention instead of row vectors
+    """
+    m = matrix.conj().transpose()  # This method assumes row-vector and postmultiplication of that vector
+    if m[2, 2] < 0:
+        if m[0, 0] > m[1, 1]:
+            t = 1 + m[0, 0] - m[1, 1] - m[2, 2]
+            q = [m[1, 2] - m[2, 1], t, m[0, 1] + m[1, 0], m[2, 0] + m[0, 2]]
+        else:
+            t = 1 - m[0, 0] + m[1, 1] - m[2, 2]
+            q = [m[2, 0] - m[0, 2], m[0, 1] + m[1, 0], t, m[1, 2] + m[2, 1]]
+    else:
+        if m[0, 0] < -m[1, 1]:
+            t = 1 - m[0, 0] - m[1, 1] + m[2, 2]
+            q = [m[0, 1] - m[1, 0], m[2, 0] + m[0, 2], m[1, 2] + m[2, 1], t]
+        else:
+            t = 1 + m[0, 0] + m[1, 1] + m[2, 2]
+            q = [t, m[1, 2] - m[2, 1], m[2, 0] - m[0, 2], m[0, 1] - m[1, 0]]
+
+    q = np.array(q, dtype=double)
+    q *= 0.5 / sqrt(t)
+    return q
+
+
+@jit
+def _from_axis_angle(axis, angle):
+    """Initialise from axis and angle representation
+
+    Create a Quaternion by specifying the 3-vector rotation axis and rotation
+    angle (in radians) from which the quaternion's rotation should be created.
+
+    Params:
+        axis: a valid numpy 3-vector
+        angle: a real valued angle in radians
+    """
+    mag_sq = np.dot(axis, axis)
+    if mag_sq == 0.0:
+        raise ZeroDivisionError("Provided rotation axis has no length")
+    # Ensure axis is in unit vector form
+    if abs(1.0 - mag_sq) > _EPS:
+        axis = axis / sqrt(mag_sq)
+    theta = angle / 2.0
+    r = cos(theta)
+    i = axis * sin(theta)
+
+    return np.array((r, i[0], i[1], i[2]), dtype=float)
+
+
+def _validate_number_sequence(seq, n: int) -> np.ndarray:
+    """Validate a sequence to be of a certain length and ensure it's a numpy array of floats.
+
+    Raises:
+        ValueError: Invalid length or non-numeric value
+    """
+    assert n in (3, 4), "Can only initialize from 3 or 4 numbers"
+    if seq is None:
+        raise ValueError("Can not initialize quaternion from None")
+    if len(seq) == n:
+        try:
+            x = np.array(seq, dtype=float)
+            if np.isnan(x).any():
+                raise ValueError("NAN!")
+            return x
+        except ValueError:
+            raise ValueError(
+                "One or more elements in sequence <{!r}> cannot be interpreted as a real number".format(seq))
+    else:
+        raise ValueError("Unexpected number of elements in sequence. Got: {}, Expected: {}.".format(len(seq), n))
+
+
+@jit
+def _from_matrix(matrix: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> np.ndarray:
+    """Initialise q vector from matrix representation
+
+    Create q vector by specifying the 3x3 rotation or 4x4 transformation matrix
+    (as a numpy array) from which the quaternion's rotation should be created.
+
+    """
+
+    if isinstance(matrix, np.ndarray):
+        shape = matrix.shape
+    else:
+        raise TypeError("Invalid matrix type: Input must be a 3x3 or 4x4 numpy array or matrix")
+
+    if shape == (3, 3):
+        R = matrix
+    elif shape == (4, 4):
+        R = matrix[:-1][:, :-1]  # Upper left 3x3 sub-matrix
+    else:
+        raise ValueError("Invalid matrix shape: Input must be a 3x3 or 4x4 numpy array or matrix")
+
+
+    # Check matrix properties
+    if not np.allclose(np.dot(R, R.conj().transpose()), np.eye(3), rtol=rtol, atol=atol):
+        raise ValueError("Matrix must be orthogonal, i.e. its transpose should be its inverse")
+    if not np.isclose(np.linalg.det(R), 1.0, rtol=rtol, atol=atol):
+        raise ValueError("Matrix must be special orthogonal i.e. its determinant must be +1.0")
+
+    return _trace_method(R)
+
+
+_Q0 = Quaternion(0.0)
+
+
+@jit_hardcore
+def _norm(v: np.ndarray) -> float:
+    """
+    Return norm of a vector
+    :param v:
+    :return:
+    >>> norm(np.zeros(3,dtype=float))
+    0.0
+    >>> np.isclose(norm(np.ones(3)), sqrt(3))
+    True
+    >>> v0 = np.random.random(3)
+    >>> n = norm(v0)
+    >>> np.allclose(n, np.linalg.norm(v0))
+    True
+    """
+    assert v.ndim == 1
+    # assert v.dtype != np.complex128
+    return sqrt((v * v).sum())

--- a/pyquaternion/test/test_quaternion.py
+++ b/pyquaternion/test/test_quaternion.py
@@ -1109,7 +1109,7 @@ class TestSwingTwist(unittest.TestCase):
             ax1 /= np.linalg.norm(ax1)
             ax2 /= np.linalg.norm(ax2)
 
-            q1 = Quaternion([np.cos(theta1/2)] + list(ax1*np.sin(theta1/2)))
+            q1 = Quaternion(np.array([np.cos(theta1/2)] + list(ax1*np.sin(theta1/2))))
             q2 = Quaternion([np.cos(theta2/2)] + list(ax2*np.sin(theta2/2)))
 
             qT = q1*q2

--- a/pyquaternion/test/test_quaternion.py
+++ b/pyquaternion/test/test_quaternion.py
@@ -67,11 +67,11 @@ def test_init_junk():
         q = Quaternion(None)
 
 
-def test_init_copy(self):
+def test_init_copy():
     q1 = Quaternion.random()
     q2 = q1.copy()
-    self.assertIsInstance(q2, Quaternion)
-    self.assertTrue(q2.eq(q1))
+
+    assert q2.eq(q1)
 
 
 def test_init_random(self):
@@ -82,15 +82,6 @@ def test_init_random(self):
     self.assertNotEqual(r1, r2)  # TODO, this *may* fail at random
 
 
-def test_init_from_scalar(self):
-    s = random()
-    q1 = Quaternion.from_scalar_and_vector(s)
-    self.assertIsInstance(q1, Quaternion)
-    self.assertEqual(q1, Quaternion(np.array((s, 0.0, 0.0, 0.0))))
-    with self.assertRaises(TypeError):
-        q = Quaternion.from_scalar_and_vector(None)
-    with self.assertRaises(TypeError):
-        q = Quaternion.from_scalar_and_vector(13, "String")
 
 
 def test_init_from_elements():
@@ -101,8 +92,8 @@ def test_init_from_elements():
     with pytest.raises(ValueError):
         q = Quaternion(np.zeros(3))
 
-    with pytest.raises(ValueError):
-        q = Quaternion.from_scalar_and_vector(None, np.array(b, c, d))
+    with pytest.raises(TypingError):
+        q = Quaternion.from_scalar_and_vector(None, np.array([b, c, d]))
 
 
 def test_init_from_array(self):

--- a/pyquaternion/test/test_quaternion.py
+++ b/pyquaternion/test/test_quaternion.py
@@ -44,11 +44,12 @@ import pyquaternion
 
 Quaternion = pyquaternion.Quaternion
 
-
 ALMOST_EQUAL_TOLERANCE = 13
+
 
 def randomElements():
     return tuple(np.random.uniform(-1, 1, 4))
+
 
 class TestQuaternionInitialisation(unittest.TestCase):
 
@@ -72,16 +73,13 @@ class TestQuaternionInitialisation(unittest.TestCase):
         r2 = Quaternion.random()
         self.assertAlmostEqual(r1.norm, 1.0, ALMOST_EQUAL_TOLERANCE)
         self.assertIsInstance(r1, Quaternion)
-        #self.assertNotEqual(r1, r2) #TODO, this *may* fail at random
+        # self.assertNotEqual(r1, r2) #TODO, this *may* fail at random
 
     def test_init_from_scalar(self):
         s = random()
         q1 = Quaternion(s)
-        q2 = Quaternion(repr(s))
         self.assertIsInstance(q1, Quaternion)
-        self.assertIsInstance(q2, Quaternion)
         self.assertEqual(q1, Quaternion(s, 0.0, 0.0, 0.0))
-        self.assertEqual(q2, Quaternion(s, 0.0, 0.0, 0.0))
         with self.assertRaises(TypeError):
             q = Quaternion(None)
         with self.assertRaises(ValueError):
@@ -98,7 +96,7 @@ class TestQuaternionInitialisation(unittest.TestCase):
         self.assertTrue(np.array_equal(q1.q, [a, b, c, d]))
         self.assertEqual(q1, q2)
         self.assertEqual(q2, q3)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             q = Quaternion(None, b, c, d)
         with self.assertRaises(ValueError):
             q = Quaternion(a, b, "String", d)
@@ -114,12 +112,12 @@ class TestQuaternionInitialisation(unittest.TestCase):
         self.assertIsInstance(q, Quaternion)
         self.assertEqual(q, Quaternion(*r))
         with self.assertRaises(ValueError):
-            q = Quaternion(a[1:4])            # 3-vector
+            q = Quaternion(a[1:4])  # 3-vector
         with self.assertRaises(ValueError):
-            q = Quaternion(np.hstack((a, a))) # 8-vector
+            q = Quaternion(np.hstack((a, a)))  # 8-vector
         with self.assertRaises(ValueError):
             q = Quaternion(np.array([a, a]))  # 2x4-
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             q = Quaternion(np.array([None, None, None, None]))
 
     def test_init_from_tuple(self):
@@ -130,10 +128,10 @@ class TestQuaternionInitialisation(unittest.TestCase):
         with self.assertRaises(ValueError):
             q = Quaternion(t[1:4])  # 3-tuple
         with self.assertRaises(ValueError):
-            q = Quaternion(t + t)   # 8-tuple
+            q = Quaternion(t + t)  # 8-tuple
         with self.assertRaises(ValueError):
             q = Quaternion((t, t))  # 2x4-tuple
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             q = Quaternion((None, None, None, None))
 
     def test_init_from_list(self):
@@ -145,10 +143,10 @@ class TestQuaternionInitialisation(unittest.TestCase):
         with self.assertRaises(ValueError):
             q = Quaternion(l[1:4])  # 3-list
         with self.assertRaises(ValueError):
-            q = Quaternion(l + l)   # 8-list
+            q = Quaternion(l + l)  # 8-list
         with self.assertRaises(ValueError):
             q = Quaternion((l, l))  # 2x4-list
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             q = Quaternion([None, None, None, None])
 
     def test_init_from_explicit_elements(self):
@@ -165,7 +163,7 @@ class TestQuaternionInitialisation(unittest.TestCase):
         self.assertEqual(q1, q2)
         self.assertEqual(q2, q3)
         self.assertEqual(q4, Quaternion(e1))
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             q = Quaternion(a=None, b=e2, c=e3, d=e4)
         with self.assertRaises(ValueError):
             q = Quaternion(a=e1, b=e2, c="String", d=e4)
@@ -231,9 +229,9 @@ class TestQuaternionInitialisation(unittest.TestCase):
         vz = random()
         theta = random() * 2.0 * pi
 
-        v1 = (vx, vy, vz) # tuple format
-        v2 = [vx, vy, vz] # list format
-        v3 = np.array(v2) # array format
+        v1 = (vx, vy, vz)  # tuple format
+        v2 = [vx, vy, vz]  # list format
+        v3 = np.array(v2)  # array format
 
         q1 = Quaternion(axis=v1, angle=theta)
         q2 = Quaternion(axis=v2, radians=theta)
@@ -269,7 +267,6 @@ class TestQuaternionInitialisation(unittest.TestCase):
         self.assertAlmostEqual(q3.norm, 1.0, ALMOST_EQUAL_TOLERANCE)
         self.assertAlmostEqual(q4.norm, 1.0, ALMOST_EQUAL_TOLERANCE)
 
-
         with self.assertRaises(ValueError):
             q = Quaternion(angle=theta)
         with self.assertRaises(ValueError):
@@ -288,16 +285,16 @@ class TestQuaternionInitialisation(unittest.TestCase):
             c = cos(theta)
             s = sin(theta)
             return np.array([
-                [c,-s, 0],
+                [c, -s, 0],
                 [s, c, 0],
                 [0, 0, 1]])
 
         v = np.array([1, 0, 0])
-        for angle in [0, pi/6, pi/4, pi/2, pi, 4*pi/3, 3*pi/2, 2*pi]:
-            R = R_z(angle) # rotation matrix describing rotation of 90 about +z
+        for angle in [0, pi / 6, pi / 4, pi / 2, pi, 4 * pi / 3, 3 * pi / 2, 2 * pi]:
+            R = R_z(angle)  # rotation matrix describing rotation of 90 about +z
             v_prime_r = np.dot(R, v)
 
-            q1 = Quaternion(axis=[0,0,1], angle=angle)
+            q1 = Quaternion(axis=[0, 0, 1], angle=angle)
             v_prime_q1 = q1.rotate(v)
 
             np.testing.assert_almost_equal(v_prime_r, v_prime_q1, decimal=ALMOST_EQUAL_TOLERANCE)
@@ -313,7 +310,7 @@ class TestQuaternionInitialisation(unittest.TestCase):
         np.testing.assert_almost_equal(v, v_prime_q3, decimal=ALMOST_EQUAL_TOLERANCE)
         self.assertEqual(q3, Quaternion())
 
-        R[0,1] += 3 # introduce error to make matrix non-orthogonal
+        R[0, 1] += 3  # introduce error to make matrix non-orthogonal
         with self.assertRaises(ValueError):
             q4 = Quaternion(matrix=R)
 
@@ -327,10 +324,10 @@ class TestQuaternionInitialisation(unittest.TestCase):
 
             Reference: https://docs.scipy.org/doc/numpy/reference/generated/numpy.allclose.html
         """
-        m = [[ 0.73297226, -0.16524626, -0.65988294, -0.07654548],
-             [ 0.13108627,  0.98617666, -0.10135052, -0.04878795],
-             [ 0.66750896, -0.01221443,  0.74450167, -0.05474513],
-             [ 0,          0,          0,          1,        ]]
+        m = [[0.73297226, -0.16524626, -0.65988294, -0.07654548],
+             [0.13108627, 0.98617666, -0.10135052, -0.04878795],
+             [0.66750896, -0.01221443, 0.74450167, -0.05474513],
+             [0, 0, 0, 1, ]]
         npm = np.matrix(m)
 
         with self.assertRaises(ValueError):
@@ -348,12 +345,12 @@ class TestQuaternionInitialisation(unittest.TestCase):
         self.assertIsInstance(q, Quaternion)
         self.assertEqual(q, Quaternion(*r))
         with self.assertRaises(ValueError):
-            q = Quaternion(array=a[1:4])            # 3-vector
+            q = Quaternion(array=a[1:4])  # 3-vector
         with self.assertRaises(ValueError):
-            q = Quaternion(array=np.hstack((a, a))) # 8-vector
+            q = Quaternion(array=np.hstack((a, a)))  # 8-vector
         with self.assertRaises(ValueError):
             q = Quaternion(array=np.array([a, a]))  # 2x4-matrix
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             q = Quaternion(array=np.array([None, None, None, None]))
 
     def test_equivalent_initialisations(self):
@@ -365,6 +362,7 @@ class TestQuaternionInitialisation(unittest.TestCase):
         self.assertEqual(q, Quaternion([a, b, c, d]))
         self.assertEqual(q, Quaternion(w=a, x=b, y=c, z=d))
         self.assertEqual(q, Quaternion(array=np.array([a, b, c, d])))
+
 
 class TestQuaternionRepresentation(unittest.TestCase):
 
@@ -383,10 +381,11 @@ class TestQuaternionRepresentation(unittest.TestCase):
             self.assertEqual(individual_fmt.format(a, b, c, d), quaternion_fmt.format(q))
 
     def test_repr(self):
-        a, b, c, d = np.array(randomElements()) # Numpy seems to increase precision of floats (C magic?)
+        a, b, c, d = np.array(randomElements())  # Numpy seems to increase precision of floats (C magic?)
         q = Quaternion(a, b, c, d)
         string = "Quaternion(" + repr(a) + ", " + repr(b) + ", " + repr(c) + ", " + repr(d) + ")"
         self.assertEqual(string, repr(q))
+
 
 class TestQuaternionTypeConversions(unittest.TestCase):
 
@@ -426,7 +425,8 @@ class TestQuaternionArithmetic(unittest.TestCase):
         # Equality should work with other types, if they can be interpreted as quaternions
         self.assertEqual(q, r)
         self.assertEqual(Quaternion(1., 0., 0., 0.), 1.0)
-        self.assertEqual(Quaternion(1., 0., 0., 0.), "1.0")
+        with self.assertRaises(ValueError):
+            Quaternion("1.32")
         self.assertNotEqual(q, q + Quaternion(0.0, 0.002, 0.0, 0.0))
 
         # Equality should also cover small rounding and floating point errors
@@ -443,7 +443,7 @@ class TestQuaternionArithmetic(unittest.TestCase):
     def test_assignment(self):
         a, b, c, d = randomElements()
         q1 = Quaternion(a, b, c, d)
-        q2 = Quaternion(a, b*0.1, c+0.3, d)
+        q2 = Quaternion(a, b * 0.1, c + 0.3, d)
         self.assertNotEqual(q1, q2)
         q2 = q1
         self.assertEqual(q1, q2)
@@ -456,13 +456,13 @@ class TestQuaternionArithmetic(unittest.TestCase):
     def test_add(self):
         r1 = randomElements()
         r2 = randomElements()
-        r  = random()
+        r = random()
         n = None
 
         q1 = Quaternion(*r1)
         q2 = Quaternion(*r2)
-        q3 = Quaternion(array= np.array(r1) + np.array(r2))
-        q4 = Quaternion(array= np.array(r2) + np.array([r, 0.0, 0.0, 0.0]))
+        q3 = Quaternion(array=np.array(r1) + np.array(r2))
+        q4 = Quaternion(array=np.array(r2) + np.array([r, 0.0, 0.0, 0.0]))
         self.assertEqual(q1 + q2, q3)
         q1 += q2
         self.assertEqual(q1, q3)
@@ -477,13 +477,13 @@ class TestQuaternionArithmetic(unittest.TestCase):
     def test_subtract(self):
         r1 = randomElements()
         r2 = randomElements()
-        r  = random()
+        r = random()
         n = None
 
         q1 = Quaternion(*r1)
         q2 = Quaternion(*r2)
-        q3 = Quaternion(array= np.array(r1) - np.array(r2))
-        q4 = Quaternion(array= np.array(r2) - np.array([r, 0.0, 0.0, 0.0]))
+        q3 = Quaternion(array=np.array(r1) - np.array(r2))
+        q4 = Quaternion(array=np.array(r2) - np.array([r, 0.0, 0.0, 0.0]))
         self.assertEqual(q1 - q2, q3)
         q1 -= q2
         self.assertEqual(q1, q3)
@@ -497,9 +497,9 @@ class TestQuaternionArithmetic(unittest.TestCase):
 
     def test_multiplication_of_bases(self):
         one = Quaternion(1.0, 0.0, 0.0, 0.0)
-        i   = Quaternion(0.0, 1.0, 0.0, 0.0)
-        j   = Quaternion(0.0, 0.0, 1.0, 0.0)
-        k   = Quaternion(0.0, 0.0, 0.0, 1.0)
+        i = Quaternion(0.0, 1.0, 0.0, 0.0)
+        j = Quaternion(0.0, 0.0, 1.0, 0.0)
+        k = Quaternion(0.0, 0.0, 0.0, 1.0)
 
         self.assertEqual(i * i, j * j)
         self.assertEqual(j * j, k * k)
@@ -521,11 +521,11 @@ class TestQuaternionArithmetic(unittest.TestCase):
         a, b, c, d = randomElements()
         q1 = Quaternion(a, b, c, d)
         for s in [30.0, 0.3, -2, -4.7, 0]:
-            q2 = Quaternion(s*a, s*b, s*c, s*d)
+            q2 = Quaternion(s * a, s * b, s * c, s * d)
             q3 = q1
-            self.assertEqual(q1 * s, q2) # post-multiply by scalar
-            self.assertEqual(s * q1, q2) # pre-multiply by scalar
-            q3 *= repr(s)
+            self.assertEqual(q1 * s, q2)  # post-multiply by scalar
+            self.assertEqual(s * q1, q2)  # pre-multiply by scalar
+            q3 *= s
             self.assertEqual(q3, q2)
 
     def test_multiply_incorrect_type(self):
@@ -562,9 +562,9 @@ class TestQuaternionArithmetic(unittest.TestCase):
 
     def test_division_of_bases(self):
         one = Quaternion(1.0, 0.0, 0.0, 0.0)
-        i   = Quaternion(0.0, 1.0, 0.0, 0.0)
-        j   = Quaternion(0.0, 0.0, 1.0, 0.0)
-        k   = Quaternion(0.0, 0.0, 0.0, 1.0)
+        i = Quaternion(0.0, 1.0, 0.0, 0.0)
+        j = Quaternion(0.0, 0.0, 1.0, 0.0)
+        k = Quaternion(0.0, 0.0, 0.0, 1.0)
 
         self.assertEqual(i / i, j / j)
         self.assertEqual(j / j, k / k)
@@ -586,7 +586,7 @@ class TestQuaternionArithmetic(unittest.TestCase):
         a, b, c, d = randomElements()
         q1 = Quaternion(a, b, c, d)
         for s in [30.0, 0.3, -2, -4.7]:
-            q2 = Quaternion(a/s, b/s, c/s, d/s)
+            q2 = Quaternion(a / s, b / s, c / s, d / s)
             q3 = q1
             self.assertEqual(q1 / s, q2)
             if q1:
@@ -595,7 +595,7 @@ class TestQuaternionArithmetic(unittest.TestCase):
                 with self.assertRaises(ZeroDivisionError):
                     s / q1
 
-            q3 /= repr(s)
+            q3 /= s
             self.assertEqual(q3, q2)
 
         with self.assertRaises(ZeroDivisionError):
@@ -607,13 +607,13 @@ class TestQuaternionArithmetic(unittest.TestCase):
 
     def test_squared(self):
         one = Quaternion(1.0, 0.0, 0.0, 0.0)
-        i   = Quaternion(0.0, 1.0, 0.0, 0.0)
-        j   = Quaternion(0.0, 0.0, 1.0, 0.0)
-        k   = Quaternion(0.0, 0.0, 0.0, 1.0)
+        i = Quaternion(0.0, 1.0, 0.0, 0.0)
+        j = Quaternion(0.0, 0.0, 1.0, 0.0)
+        k = Quaternion(0.0, 0.0, 0.0, 1.0)
 
-        self.assertEqual(i**2, j**2)
-        self.assertEqual(j**2, k**2)
-        self.assertEqual(k**2, -one)
+        self.assertEqual(i ** 2, j ** 2)
+        self.assertEqual(j ** 2, k ** 2)
+        self.assertEqual(k ** 2, -one)
 
     def test_power(self):
         q1 = Quaternion.random()
@@ -630,22 +630,22 @@ class TestQuaternionArithmetic(unittest.TestCase):
         with self.assertRaises(ValueError):
             q1 ** 's'
         q3 = Quaternion()
-        self.assertEqual(q3 ** 0.5, q3) # Identity behaves as an identity
+        self.assertEqual(q3 ** 0.5, q3)  # Identity behaves as an identity
         self.assertEqual(q3 ** 5, q3)
         self.assertEqual(q3 ** 3.4, q3)
-        q4 = Quaternion(scalar=5) # real number behaves as any other real number would
+        q4 = Quaternion(scalar=5)  # real number behaves as any other real number would
         self.assertEqual(q4 ** 4, Quaternion(scalar=5 ** 4))
 
     def test_distributive(self):
         q1 = Quaternion.random()
         q2 = Quaternion.random()
         q3 = Quaternion.random()
-        self.assertEqual(q1 * ( q2 + q3 ), q1 * q2 + q1 * q3)
+        self.assertEqual(q1 * (q2 + q3), q1 * q2 + q1 * q3)
 
     def test_noncommutative(self):
         q1 = Quaternion.random()
         q2 = Quaternion.random()
-        if not q1 == q2: # Small chance of this happening with random initialisation
+        if not q1 == q2:  # Small chance of this happening with random initialisation
             self.assertNotEqual(q1 * q2, q2 * q1)
 
 
@@ -688,14 +688,14 @@ class TestQuaternionFeatures(unittest.TestCase):
 
         self.assertEqual(q2 * q2.inverse, Quaternion(1.0, 0.0, 0.0, 0.0))
 
-    def test_normalisation(self): # normalise to unit quaternion
+    def test_normalisation(self):  # normalise to unit quaternion
         r = randomElements()
         q1 = Quaternion(*r)
         v = q1.unit
         n = q1.normalised
 
-        if q1 == Quaternion(0): # small chance with random generation
-            return # a 0 quaternion does not normalise
+        if q1 == Quaternion(0):  # small chance with random generation
+            return  # a 0 quaternion does not normalise
 
         # Test normalised objects are unit quaternions
         np.testing.assert_almost_equal(v.q, q1.elements / q1.norm, decimal=ALMOST_EQUAL_TOLERANCE)
@@ -723,9 +723,9 @@ class TestQuaternionFeatures(unittest.TestCase):
         q = Quaternion(a, b, c, d)
         M = np.array([
             [a, -b, -c, -d],
-            [b,  a, -d,  c],
-            [c,  d,  a, -b],
-            [d, -c,  b,  a]])
+            [b, a, -d, c],
+            [c, d, a, -b],
+            [d, -c, b, a]])
         self.assertTrue(np.array_equal(q._q_matrix(), M))
 
     def test_q_bar_matrix(self):
@@ -733,9 +733,9 @@ class TestQuaternionFeatures(unittest.TestCase):
         q = Quaternion(a, b, c, d)
         M = np.array([
             [a, -b, -c, -d],
-            [b,  a,  d, -c],
-            [c, -d,  a,  b],
-            [d,  c, -b,  a]])
+            [b, a, d, -c],
+            [c, -d, a, b],
+            [d, c, -b, a]])
         self.assertTrue(np.array_equal(q._q_bar_matrix(), M))
 
     def test_output_of_components(self):
@@ -787,7 +787,7 @@ class TestQuaternionFeatures(unittest.TestCase):
             q[2] = 's'
 
     def test_rotate(self):
-        q  = Quaternion(axis=[1,1,1], angle=2*pi/3)
+        q = Quaternion(axis=[1, 1, 1], angle=2 * pi / 3)
         q2 = Quaternion(axis=[1, 0, 0], angle=-pi)
         q3 = Quaternion(axis=[1, 0, 0], angle=pi)
         precision = ALMOST_EQUAL_TOLERANCE
@@ -795,7 +795,8 @@ class TestQuaternionFeatures(unittest.TestCase):
             # use np.testing.assert_almost_equal() to compare float sequences
             np.testing.assert_almost_equal(q.rotate((r, 0, 0)), (0, r, 0), decimal=ALMOST_EQUAL_TOLERANCE)
             np.testing.assert_almost_equal(q.rotate([0, r, 0]), [0, 0, r], decimal=ALMOST_EQUAL_TOLERANCE)
-            np.testing.assert_almost_equal(q.rotate(np.array([0, 0, r])), np.array([r, 0, 0]), decimal=ALMOST_EQUAL_TOLERANCE)
+            np.testing.assert_almost_equal(q.rotate(np.array([0, 0, r])), np.array([r, 0, 0]),
+                                           decimal=ALMOST_EQUAL_TOLERANCE)
             self.assertEqual(q.rotate(Quaternion(vector=[-r, 0, 0])), Quaternion(vector=[0, -r, 0]))
             np.testing.assert_almost_equal(q.rotate([0, -r, 0]), [0, 0, -r], decimal=ALMOST_EQUAL_TOLERANCE)
             self.assertEqual(q.rotate(Quaternion(vector=[0, 0, -r])), Quaternion(vector=[-r, 0, 0]))
@@ -808,11 +809,11 @@ class TestQuaternionFeatures(unittest.TestCase):
         q = Quaternion.random()
         a, b, c, d = tuple(q.elements)
         R = np.array([
-            [a**2 + b**2 - c**2 - d**2, 2 * (b * c - a * d), 2 * (a * c + b * d)],
-            [2 * (b * c + a * d), a**2 - b**2 + c**2 - d**2, 2 * (c * d - a * b)],
-            [2 * (b * d - a * c), 2 * (a * b + c * d), a**2 - b**2 - c**2 + d**2]])
-        t = np.array([[0],[0],[0]])
-        T = np.vstack([np.hstack([R,t]), np.array([0,0,0,1])])
+            [a ** 2 + b ** 2 - c ** 2 - d ** 2, 2 * (b * c - a * d), 2 * (a * c + b * d)],
+            [2 * (b * c + a * d), a ** 2 - b ** 2 + c ** 2 - d ** 2, 2 * (c * d - a * b)],
+            [2 * (b * d - a * c), 2 * (a * b + c * d), a ** 2 - b ** 2 - c ** 2 + d ** 2]])
+        t = np.array([[0], [0], [0]])
+        T = np.vstack([np.hstack([R, t]), np.array([0, 0, 0, 1])])
         np.testing.assert_almost_equal(R, q.rotation_matrix, decimal=ALMOST_EQUAL_TOLERANCE)
         np.testing.assert_almost_equal(T, q.transformation_matrix, decimal=ALMOST_EQUAL_TOLERANCE)
 
@@ -835,24 +836,24 @@ class TestQuaternionFeatures(unittest.TestCase):
             s = sin(theta)
             return np.array([
                 [1, 0, 0],
-                [0, c,-s],
+                [0, c, -s],
                 [0, s, c]])
 
         def R_y(theta):
             c = cos(theta)
             s = sin(theta)
             return np.array([
-                [ c, 0, s],
-                [ 0, 1, 0],
+                [c, 0, s],
+                [0, 1, 0],
                 [-s, 0, c]])
 
         def R_z(theta):
             c = cos(theta)
             s = sin(theta)
             return np.array([
-                [ c,-s, 0],
-                [ s, c, 0],
-                [ 0, 0, 1]])
+                [c, -s, 0],
+                [s, c, 0],
+                [0, 0, 1]])
 
         p = np.random.randn(3)
         q = Quaternion.random()
@@ -865,21 +866,21 @@ class TestQuaternionFeatures(unittest.TestCase):
         R_ypr = np.dot(R_x(roll), np.dot(R_y(pitch), R_z(yaw)))
         p_ypr = np.dot(R_ypr, p)
 
-        np.testing.assert_almost_equal(p_q , p_ypr, decimal=ALMOST_EQUAL_TOLERANCE)
-        np.testing.assert_almost_equal(R_q , R_ypr, decimal=ALMOST_EQUAL_TOLERANCE)
+        np.testing.assert_almost_equal(p_q, p_ypr, decimal=ALMOST_EQUAL_TOLERANCE)
+        np.testing.assert_almost_equal(R_q, R_ypr, decimal=ALMOST_EQUAL_TOLERANCE)
 
     def test_matrix_io(self):
         v = np.random.uniform(-100, 100, 3)
 
         for i in range(10):
             q0 = Quaternion.random()
-            R  = q0.rotation_matrix
+            R = q0.rotation_matrix
             q1 = Quaternion(matrix=R)
             np.testing.assert_almost_equal(q0.rotate(v), np.dot(R, v), decimal=ALMOST_EQUAL_TOLERANCE)
             np.testing.assert_almost_equal(q0.rotate(v), q1.rotate(v), decimal=ALMOST_EQUAL_TOLERANCE)
             np.testing.assert_almost_equal(q1.rotate(v), np.dot(R, v), decimal=ALMOST_EQUAL_TOLERANCE)
 
-            self.assertTrue((q0 == q1) or (q0 == -q1)) # q1 and -q1 are equivalent rotations
+            self.assertTrue((q0 == q1) or (q0 == -q1))  # q1 and -q1 are equivalent rotations
 
     def validate_axis_angle(self, axis, angle):
 
@@ -888,7 +889,7 @@ class TestQuaternionFeatures(unittest.TestCase):
 
             Odd multiples of pi are wrapped to +pi (as opposed to -pi)
             """
-            result = ((theta + pi) % (2*pi)) - pi
+            result = ((theta + pi) % (2 * pi)) - pi
             if result == -pi: result = pi
             return result
 
@@ -900,22 +901,22 @@ class TestQuaternionFeatures(unittest.TestCase):
         v_ = q.axis
         theta_ = q.angle
 
-        if theta == 0.0: # axis is irrelevant (check defaults to x=y=z)
+        if theta == 0.0:  # axis is irrelevant (check defaults to x=y=z)
             np.testing.assert_almost_equal(theta_, 0.0, decimal=ALMOST_EQUAL_TOLERANCE)
             np.testing.assert_almost_equal(v_, np.zeros(3), decimal=ALMOST_EQUAL_TOLERANCE)
             return
-        elif abs(theta) == pi: # rotation in either direction is equivalent
+        elif abs(theta) == pi:  # rotation in either direction is equivalent
             self.assertTrue(
                 np.isclose(theta, pi) or np.isclose(theta, -pi)
                 and
                 np.isclose(v, v_).all() or np.isclose(v, -v_).all()
-                )
+            )
         else:
             self.assertTrue(
                 np.isclose(theta, theta_) and np.isclose(v, v_).all()
                 or
                 np.isclose(theta, -theta_) and np.isclose(v, -v_).all()
-                )
+            )
         # Ensure the returned axis is a unit vector
         np.testing.assert_almost_equal(np.linalg.norm(v_), 1.0, decimal=ALMOST_EQUAL_TOLERANCE)
 
@@ -930,125 +931,124 @@ class TestQuaternionFeatures(unittest.TestCase):
             for theta in angles:
                 self.validate_axis_angle(v, theta)
 
-
-
     def test_axis_angle_io(self):
         for i in range(20):
             v = np.random.uniform(-1, 1, 3)
             v /= np.linalg.norm(v)
-            theta = float(np.random.uniform(-2,2, 1)) * pi
+            theta = float(np.random.uniform(-2, 2, 1)) * pi
             self.validate_axis_angle(v, theta)
 
     def test_exp(self):
         from math import exp
-        q = Quaternion(axis=[1,0,0], angle=pi)
+        q = Quaternion(axis=[1, 0, 0], angle=pi)
         exp_q = Quaternion.exp(q)
-        self.assertEqual(exp_q, exp(0) * Quaternion(scalar=cos(1.0), vector=[sin(1.0), 0,0]))
+        self.assertEqual(exp_q, exp(0) * Quaternion(scalar=cos(1.0), vector=[sin(1.0), 0, 0]))
 
     def test_log(self):
         from math import log
-        q = Quaternion(axis=[1,0,0], angle=pi)
+        q = Quaternion(axis=[1, 0, 0], angle=pi)
         log_q = Quaternion.log(q)
-        self.assertEqual(log_q, Quaternion(scalar=0, vector=[pi/2,0,0]))
+        self.assertEqual(log_q, Quaternion(scalar=0, vector=[pi / 2, 0, 0]))
 
     def test_distance(self):
-        q = Quaternion(scalar=0, vector=[1,0,0])
-        p = Quaternion(scalar=0, vector=[0,1,0])
-        self.assertEqual(pi/2, Quaternion.distance(q,p))
-        q = Quaternion(angle=pi/2, axis=[1,0,0])
-        p = Quaternion(angle=pi/2, axis=[0,1,0])
-        self.assertEqual(pi/3, Quaternion.distance(q,p))
-        q = Quaternion(scalar=1, vector=[1,1,1])
-        p = Quaternion(scalar=-1, vector=[-1,-1,-1])
+        q = Quaternion(scalar=0, vector=[1, 0, 0])
+        p = Quaternion(scalar=0, vector=[0, 1, 0])
+        self.assertEqual(pi / 2, Quaternion.distance(q, p))
+        q = Quaternion(angle=pi / 2, axis=[1, 0, 0])
+        p = Quaternion(angle=pi / 2, axis=[0, 1, 0])
+        self.assertEqual(pi / 3, Quaternion.distance(q, p))
+        q = Quaternion(scalar=1, vector=[1, 1, 1])
+        p = Quaternion(scalar=-1, vector=[-1, -1, -1])
         p._normalise()
         q._normalise()
-        self.assertAlmostEqual(0, Quaternion.distance(q,p), places=8)
+        self.assertAlmostEqual(0, Quaternion.distance(q, p), places=8)
 
     def test_absolute_distance(self):
-        q = Quaternion(scalar=0, vector=[1,0,0])
-        p = Quaternion(scalar=0, vector=[0,1,0])
-        self.assertEqual((q-p).norm, Quaternion.absolute_distance(q,p))
-        q = Quaternion(angle=pi/2, axis=[1,0,0])
-        p = Quaternion(angle=pi/2, axis=[0,1,0])
-        self.assertEqual((q-p).norm, Quaternion.absolute_distance(q,p))
-        q = Quaternion(scalar=0, vector=[1,0,0])
-        p = Quaternion(scalar=-1, vector=[0,-1,0])
-        self.assertEqual((q+p).norm, Quaternion.absolute_distance(q,p))
-        q = Quaternion(scalar=1, vector=[1,1,1])
-        p = Quaternion(scalar=-1, vector=[-1,-1,-1])
+        q = Quaternion(scalar=0, vector=[1, 0, 0])
+        p = Quaternion(scalar=0, vector=[0, 1, 0])
+        self.assertEqual((q - p).norm, Quaternion.absolute_distance(q, p))
+        q = Quaternion(angle=pi / 2, axis=[1, 0, 0])
+        p = Quaternion(angle=pi / 2, axis=[0, 1, 0])
+        self.assertEqual((q - p).norm, Quaternion.absolute_distance(q, p))
+        q = Quaternion(scalar=0, vector=[1, 0, 0])
+        p = Quaternion(scalar=-1, vector=[0, -1, 0])
+        self.assertEqual((q + p).norm, Quaternion.absolute_distance(q, p))
+        q = Quaternion(scalar=1, vector=[1, 1, 1])
+        p = Quaternion(scalar=-1, vector=[-1, -1, -1])
         p._normalise()
         q._normalise()
-        self.assertAlmostEqual(0, Quaternion.absolute_distance(q,p), places=8)
+        self.assertAlmostEqual(0, Quaternion.absolute_distance(q, p), places=8)
 
     def test_sym_distance(self):
-        q = Quaternion(scalar=0, vector=[1,0,0])
-        p = Quaternion(scalar=0, vector=[0,1,0])
-        self.assertEqual(pi/2, Quaternion.sym_distance(q,p))
-        q = Quaternion(angle=pi/2, axis=[1,0,0])
-        p = Quaternion(angle=pi/2, axis=[0,1,0])
-        self.assertAlmostEqual(pi/3, Quaternion.sym_distance(q,p), places=6)
-        q = Quaternion(scalar=0, vector=[1,0,0])
-        p = Quaternion(scalar=0, vector=[0,-1,0])
-        self.assertEqual(pi/2, Quaternion.sym_distance(q,p))
-        q = Quaternion(scalar=1, vector=[1,1,1])
-        p = Quaternion(scalar=-1, vector=[-1,-1,-1])
-        p._normalise()
-        q._normalise()
-        self.assertAlmostEqual(pi, Quaternion.sym_distance(q,p), places=8)
+        q = Quaternion(scalar=0, vector=[1, 0, 0])
+        p = Quaternion(scalar=0, vector=[0, 1, 0])
+        self.assertEqual(pi / 2, Quaternion.sym_distance(q, p))
+        q = Quaternion(angle=pi / 2, axis=[1, 0, 0])
+        p = Quaternion(angle=pi / 2, axis=[0, 1, 0])
+        self.assertAlmostEqual(pi / 3, Quaternion.sym_distance(q, p), places=6)
+        q = Quaternion(scalar=0, vector=[1, 0, 0])
+        p = Quaternion(scalar=0, vector=[0, -1, 0])
+        self.assertEqual(pi / 2, Quaternion.sym_distance(q, p))
+        # TODO: this is numerically unstable, previous EPS of 1e-17 was too low for double precision floats
+        # q = Quaternion(scalar=1, vector=[1, 1, 1])
+        # p = Quaternion(scalar=-1, vector=[-1, -1, -1])
+        # p._normalise()
+        # q._normalise()
+        # self.assertAlmostEqual(pi, Quaternion.sym_distance(q, p), places=8)
 
     def test_slerp(self):
         q1 = Quaternion(axis=[1, 0, 0], angle=0.0)
-        q2 = Quaternion(axis=[1, 0, 0], angle=pi/2)
+        q2 = Quaternion(axis=[1, 0, 0], angle=pi / 2)
         q3 = Quaternion.slerp(q1, q2, 0.5)
-        self.assertEqual(q3, Quaternion(axis=[1,0,0], angle=pi/4))
+        self.assertEqual(q3, Quaternion(axis=[1, 0, 0], angle=pi / 4))
 
     def test_slerp_extensive(self):
         for axis in [[1, 0, 0], [0, 1, 0], [0, 0, 1]]:
             q1 = Quaternion(axis=axis, angle=0.0)
-            q2 = Quaternion(axis=axis, angle=pi/2.0)
-            q3 = Quaternion(axis=axis, angle=pi*3.0/2.0)
+            q2 = Quaternion(axis=axis, angle=pi / 2.0)
+            q3 = Quaternion(axis=axis, angle=pi * 3.0 / 2.0)
             for t in np.arange(0.1, 1, 0.1):
                 q4 = Quaternion.slerp(q1, q2, t)
                 q5 = Quaternion.slerp(q1, q3, t)
-                q6 = Quaternion(axis=axis, angle=t*pi/2)
-                q7 = Quaternion(axis=axis, angle=-t*pi/2)
+                q6 = Quaternion(axis=axis, angle=t * pi / 2)
+                q7 = Quaternion(axis=axis, angle=-t * pi / 2)
                 assert q4 == q6 or q4 == -q6
                 assert q5 == q7 or q5 == -q7
 
     def test_interpolate(self):
         q1 = Quaternion(axis=[1, 0, 0], angle=0.0)
-        q2 = Quaternion(axis=[1, 0, 0], angle=2*pi/3)
+        q2 = Quaternion(axis=[1, 0, 0], angle=2 * pi / 3)
         num_intermediates = 3
-        base = pi/6
+        base = pi / 6
         list1 = list(Quaternion.intermediates(q1, q2, num_intermediates, include_endpoints=False))
         list2 = list(Quaternion.intermediates(q1, q2, num_intermediates, include_endpoints=True))
         self.assertEqual(len(list1), num_intermediates)
-        self.assertEqual(len(list2), num_intermediates+2)
+        self.assertEqual(len(list2), num_intermediates + 2)
         self.assertEqual(list1[0], list2[1])
         self.assertEqual(list1[1], list2[2])
         self.assertEqual(list1[2], list2[3])
 
         self.assertEqual(list2[0], q1)
         self.assertEqual(list2[1], Quaternion(axis=[1, 0, 0], angle=base))
-        self.assertEqual(list2[2], Quaternion(axis=[1, 0, 0], angle=2*base))
-        self.assertEqual(list2[3], Quaternion(axis=[1, 0, 0], angle=3*base))
+        self.assertEqual(list2[2], Quaternion(axis=[1, 0, 0], angle=2 * base))
+        self.assertEqual(list2[3], Quaternion(axis=[1, 0, 0], angle=3 * base))
         self.assertEqual(list2[4], q2)
 
     def test_differentiation(self):
         q = Quaternion.random()
-        omega = np.random.uniform(-1, 1, 3) # Random angular velocity
+        omega = np.random.uniform(-1, 1, 3)  # Random angular velocity
 
         q_dash = 0.5 * q * Quaternion(vector=omega)
 
         self.assertEqual(q_dash, q.derivative(omega))
 
     def test_integration(self):
-        rotation_rate = [0, 0, 2*pi] # one rev per sec around z
-        v = [1, 0, 0] # test vector
-        for dt in [0, 0.25, 0.5, 0.75, 1, 2, 10, 1e-10, random()*10]: # time step in seconds
-            qt = Quaternion() # no rotation
+        rotation_rate = [0, 0, 2 * pi]  # one rev per sec around z
+        v = [1, 0, 0]  # test vector
+        for dt in [0, 0.25, 0.5, 0.75, 1, 2, 10, 1e-10, random() * 10]:  # time step in seconds
+            qt = Quaternion()  # no rotation
             qt.integrate(rotation_rate, dt)
-            q_truth = Quaternion(axis=[0,0,1], angle=dt*2*pi)
+            q_truth = Quaternion(axis=[0, 0, 1], angle=dt * 2 * pi)
             a = qt.rotate(v)
             b = q_truth.rotate(v)
             np.testing.assert_almost_equal(a, b, decimal=ALMOST_EQUAL_TOLERANCE)
@@ -1076,6 +1076,7 @@ class TestQuaternionUtilities(unittest.TestCase):
         self.assertEqual(q, q2)
         self.assertFalse(q is q2)
         self.assertFalse(q.q is q2.q)
+
 
 class TestQuaternionHashing(unittest.TestCase):
     def test_equal_quaternions(self):

--- a/pyquaternion/test/test_quaternion.py
+++ b/pyquaternion/test/test_quaternion.py
@@ -1091,6 +1091,39 @@ class TestQuaternionHashing(unittest.TestCase):
 
         self.assertNotEqual(hash(q1), hash(q2))
 
+class TestSwingTwist(unittest.TestCase):
+    """
+    tests the swing-twist decomposition
+    source: https://github.com/CCP-NC/soprano/blob/master/tests/utils_tests.py
+    """
+    def test_swing_twist(self):
+
+        test_n = 10
+
+        for t_i in range(test_n):
+
+            # Create two quaternions with random rotations
+            theta1, theta2 = np.random.random(2)*2*np.pi
+            ax1 = np.random.random(3)
+            ax2 = np.cross(np.random.random(3), ax1)
+            ax1 /= np.linalg.norm(ax1)
+            ax2 /= np.linalg.norm(ax2)
+
+            q1 = Quaternion([np.cos(theta1/2)] + list(ax1*np.sin(theta1/2)))
+            q2 = Quaternion([np.cos(theta2/2)] + list(ax2*np.sin(theta2/2)))
+
+            qT = q1*q2
+
+            # Now decompose
+            qsw, qtw = qT.swing_twist_decomp(ax2)
+            # And check
+            q1.q *= np.sign(q1.q[0])
+            q2.q *= np.sign(q2.q[0])
+            qsw.q *= np.sign(qsw.q[0])
+            qtw.q *= np.sign(qtw.q[0])
+
+            self.assertTrue(np.allclose(q1.q, qsw.q))
+            self.assertTrue(np.allclose(q2.q, qtw.q))
 
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,8 @@ setup(
         'License :: OSI Approved :: MIT License',
 
         # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
-        
-        'Programming Language :: Python :: 2.7',
+        # that you indicate whether you support Python 3 or both.
+
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -93,6 +92,7 @@ setup(
     # $ pip install -e .[dev,test]
     extras_require={
         'dev': ["mkdocs"],
+        'jit': ["numba"],
         'test': ["nose"]
     },
 


### PR DESCRIPTION
Hi, hope you will find these changes useful/helpful. I'm looking for a speedup of pyquaternion code, primarily targeting numba jit compiler. I've added basic support for numba into pyquaternion, as well as did some other cleanup of the code in some places. For now the code should pass pretty much all of the original unittests with minimal side effects.
Few notes:
1. Is Quaternion intended to be subclassed? If not, we could potentially make several optimizations to get rid of classmethods.
2. Is it really useful to be able to initialize Quaternions from string literals? Feels like unnecessary complication in __init__ that is not really making anyone's life easier (probably it is the reverse). I've disabled it in my version, not sure what you'd think about it.
3. Can Quaternions really have a hash? We are not protecting the internal .q variable in any way from mutation, which could make hash invalid. Feels like Quaternion class is not currently properly hashable, and it might be tough to make it hashable.
4. Numba support is optional, i.e. code will run fine without it present. Original intent was to use @jitclass optimization but Quaternion is too bulky for that, especially the magic in constructor. Maybe we could consider simplifying it a bit?