### PR TITLE
Fixing the warning issue: Should use of ndarray instead of the matrix subclass

### DIFF
--- a/pyquaternion/test/test_quaternion.py
+++ b/pyquaternion/test/test_quaternion.py
@@ -307,7 +307,7 @@ class TestQuaternionInitialisation(unittest.TestCase):
 
             np.testing.assert_almost_equal(v_prime_q2, v_prime_r, decimal=ALMOST_EQUAL_TOLERANCE)
 
-        R = np.matrix(np.eye(3))
+        R = np.array(np.eye(3))
         q3 = Quaternion(matrix=R)
         v_prime_q3 = q3.rotate(v)
         np.testing.assert_almost_equal(v, v_prime_q3, decimal=ALMOST_EQUAL_TOLERANCE)
@@ -331,7 +331,7 @@ class TestQuaternionInitialisation(unittest.TestCase):
              [ 0.13108627,  0.98617666, -0.10135052, -0.04878795],
              [ 0.66750896, -0.01221443,  0.74450167, -0.05474513],
              [ 0,          0,          0,          1,        ]]
-        npm = np.matrix(m)
+        npm = np.array(m)
 
         with self.assertRaises(ValueError):
             Quaternion(matrix=npm)


### PR DESCRIPTION
Solving the issues that I've found in the test script. 

![Screenshot 2021-09-02 at 12 48 52](https://user-images.githubusercontent.com/47969361/131830977-3d039ee2-8e68-4e22-bd55-618c2e08a51a.png)
