### PR TITLE
Reduce numerical error

### DIFF
--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -93,6 +93,7 @@ class Quaternion:
                             "A valid rotation 'axis' parameter must be provided to describe a meaningful rotation."
                         )
                     angle = kwargs.get('radians') or self.to_radians(kwargs.get('degrees')) or kwargs.get('angle') or 0.0
+                    angle = self._wrap_angle(angle)
                     self.q = Quaternion._from_axis_angle(axis, angle).q
                 elif "array" in kwargs:
                     self.q = self._validate_number_sequence(kwargs["array"], 4)


### PR DESCRIPTION
When we set `radians` large value, it often causes numerical error.
This is because calling `_wrap_angle`   is late. 
So I try to reduce numerical error by calling `_wrap_angle` earlier.

e.x. 
` Quaternion(axis=[0.0,0.0,1.0], radians=4.0*np.pi).radians`
The current version output is `4.440892098500626e-16`
On the other hand, this PR outputs `0.0`
